### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,41 +2,49 @@
 help: ## Prints help (only for targets with comments)
 	@grep -E '^[a-zA-Z._-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-APP=stevedore
-SRC_PACKAGES=$(shell go list -mod=vendor ./... | grep -v "vendor" | grep -v "swagger")
-VERSION?=3.3.1
-BUILD?=$(shell git describe --always --dirty 2> /dev/null)
-GOLINT:=$(shell command -v golint 2> /dev/null)
-APP_EXECUTABLE="./out/$(APP)"
-RICHGO=$(shell command -v richgo 2> /dev/null)
-GOMETA_LINT=$(shell command -v golangci-lint 2> /dev/null)
-GOLANGCI_LINT_VERSION=v1.31.0
 GO111MODULE=on
+APP=stevedore
+VERSION?=3.3.1
+APP_EXECUTABLE="./out/$(APP)"
+SRC_PACKAGES=$(shell go list -mod=vendor ./... | grep -v "vendor" | grep -v "swagger")
 SHELL=bash -o pipefail
 DEFAULT_HELM_REPO_NAME?="chartmuseum"
 BUILD_ARGS="-s -w -X main.version=$(VERSION) -X main.build=$(BUILD) -X github.com/gojek/stevedore/cmd/repo.defaultHelmRepoName=$(DEFAULT_HELM_REPO_NAME)"
-
-ifeq ($(GOMETA_LINT),)
-	GOMETA_LINT=$(shell command -v $(PWD)/bin/golangci-lint 2> /dev/null)
+BUILD?=$(shell git describe --always --dirty 2> /dev/null)
+ifeq ($(BUILD),)
+	BUILD=dev
 endif
 
+GOLANGCI_LINT=$(shell command -v golangci-lint 2> /dev/null)
+GOLANGCI_LINT_VERSION=v1.31.0
+ifeq ($(GOLANGCI_LINT),)
+	GOLANGCI_LINT=$(shell command -v $(PWD)/bin/golangci-lint 2> /dev/null)
+endif
+
+RICHGO=$(shell command -v richgo 2> /dev/null)
 ifeq ($(RICHGO),)
 	GO_BINARY=go
 else
 	GO_BINARY=richgo
 endif
 
-ifeq ($(BUILD),)
-	BUILD=dev
-endif
-
 ifdef CI_COMMIT_SHORT_SHA
 	BUILD=$(CI_COMMIT_SHORT_SHA)
 endif
 
-all: setup build
+setup-richgo:
+ifeq ($(RICHGO),)
+	GO111MODULE=off $(GO_BINARY) get -u github.com/kyoh86/richgo
+endif
 
-ci: setup-golangci-lint build-common
+setup-golangci-lint:
+ifeq ($(GOLANGCI_LINT),)
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s $(GOLANGCI_LINT_VERSION)
+endif
+
+setup: setup-richgo setup-golangci-lint ensure-build-dir ## Setup environment
+
+all: setup build
 
 ensure-build-dir:
 	mkdir -p out
@@ -49,23 +57,23 @@ build-deps: ## Install dependencies
 update-deps: ## Update dependencies
 	go get -u
 
+install: ## Install stevedore
+	go install -mod=vendor -ldflags $(BUILD_ARGS)
+
+compress: compile ## Compress the binary
+	upx $(APP_EXECUTABLE)
+
+build: fmt build-common ## Build the application
+
+build-common: vet lint test compile
+
 compile: compile-app ## Compile stevedore
 
 compile-app: ensure-build-dir
 	$(GO_BINARY) build -mod=vendor -ldflags $(BUILD_ARGS) -o $(APP_EXECUTABLE) ./main.go
 
-install: ## Install stevedore
-	go install -mod=vendor -ldflags $(BUILD_ARGS)
-
 compile-linux: ensure-build-dir ## Compile stevedore for linux
 	GOOS=linux GOARCH=amd64 $(GO_BINARY) build -mod=vendor -ldflags $(BUILD_ARGS) -o $(APP_EXECUTABLE) ./main.go
-
-build: fmt build-common ## Build the application
-
-build-common: vet lint-all test compile
-
-compress: compile ## Compress the binary
-	upx $(APP_EXECUTABLE)
 
 fmt:
 	GOFLAGS="-mod=vendor" $(GO_BINARY) fmt $(SRC_PACKAGES)
@@ -73,20 +81,8 @@ fmt:
 vet:
 	$(GO_BINARY) vet -mod=vendor $(SRC_PACKAGES)
 
-setup-golangci-lint:
-ifeq ($(GOMETA_LINT),)
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s $(GOLANGCI_LINT_VERSION)
-endif
-
-setup-richgo:
-ifeq ($(RICHGO),)
-	GO111MODULE=off $(GO_BINARY) get -u github.com/kyoh86/richgo
-endif
-
-setup: setup-richgo setup-golangci-lint ensure-build-dir ## Setup environment
-
 lint: setup-golangci-lint
-	$(GOMETA_LINT) run -v
+	$(GOLANGCI_LINT) run -v
 
 test-all: test test.integration
 


### PR DESCRIPTION
There are some misses in Makefile 
1. Word `lint-all` is not replaced properly
2. There are some unused commands that confuses the user/

This commit will
1. Fix build command - rename lint-all to lint
2. Remove unused commands
3. Order commands for readability

Signed-off-by: Nithya Natarajan <nithyanatarajn@gmail.com>