### PR TITLE
Add gofmt and govet to run via golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,6 @@ run:
 linters:
   enable:
     - golint
+    - gofmt
 issues:
   exclude-use-default: false
-

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ compress: compile ## Compress the binary
 
 build: fmt build-common ## Build the application
 
-build-common: vet lint test compile
+build-common: lint test compile
 
 compile: compile-app ## Compile stevedore
 
@@ -76,9 +76,6 @@ compile-app: ensure-build-dir
 
 fmt:
 	GOFLAGS="-mod=vendor" $(GO_BINARY) fmt $(SRC_PACKAGES)
-
-vet:
-	$(GO_BINARY) vet -mod=vendor $(SRC_PACKAGES)
 
 lint: setup-golangci-lint
 	$(GOLANGCI_LINT) run -v


### PR DESCRIPTION
Add gofmt and govet to run via golangci-lint. With this, we can get rid of `fmt` and `vet` and use a universal linter in both ci (present already) and local


Signed-off-by: Nithya Natarajan <nithyanatarajn@gmail.com>