### PR TITLE
Critical bugfix: Environment variables containg "=" is not inferred correctly

### DIFF
--- a/cmd/store/local.go
+++ b/cmd/store/local.go
@@ -12,7 +12,7 @@ type Local struct{}
 func (ls Local) Fetch() map[string]interface{} {
 	envs := map[string]interface{}{}
 	for _, env := range os.Environ() {
-		pair := strings.Split(env, "=")
+		pair := strings.SplitN(env, "=", 2)
 		envs[pair[0]] = pair[1]
 	}
 	return envs

--- a/cmd/store/local_test.go
+++ b/cmd/store/local_test.go
@@ -1,0 +1,42 @@
+package store
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestFetch(t *testing.T) {
+	t.Run("should fetch envs", func(t *testing.T) {
+		_ = os.Setenv("TEST_STEVEDORE_KEY_1", "value1")
+		_ = os.Setenv("TEST_STEVEDORE_KEY_2", "value2")
+		defer func() {
+			_ = os.Unsetenv("TEST_STEVEDORE_KEY_1")
+			_ = os.Unsetenv("TEST_STEVEDORE_KEY_2")
+		}()
+
+		local := Local{}
+		envs := local.Fetch()
+
+		assert.Equal(t, envs["TEST_STEVEDORE_KEY_1"], "value1")
+		assert.Equal(t, envs["TEST_STEVEDORE_KEY_2"], "value2")
+	})
+
+	t.Run("should fetch envs containing = in value", func(t *testing.T) {
+		err := os.Setenv("TEST_STEVEDORE_KEY", "val=ue=")
+		if err != nil {
+			t.Fatalf("Failed to set env %v", err)
+		}
+		defer func() {
+			_ = os.Unsetenv("TEST_STEVEDORE_KEY")
+			if err != nil {
+				t.Fatalf("Failed to unset env %v", err)
+			}
+		}()
+
+		local := Local{}
+		envs := local.Fetch()
+
+		assert.Equal(t, envs["TEST_STEVEDORE_KEY"], "val=ue=")
+	})
+}


### PR DESCRIPTION
When environment variables contains "=" sign its not getting inferred correctly. 

How to replicate?

1. ` export REDIS_PASSWORD="dGVzdCAiYSI="`
2. Run render command using the redis example 

This is caused by splitting string of the form "envkey=value" based on "=".

