### PR TITLE
Allow enabling atomic option in helm

### DIFF
--- a/client/internal/mocks/afero.go
+++ b/client/internal/mocks/afero.go
@@ -5,38 +5,37 @@
 package mocks
 
 import (
+	gomock "github.com/golang/mock/gomock"
+	afero "github.com/spf13/afero"
 	os "os"
 	reflect "reflect"
 	time "time"
-
-	gomock "github.com/golang/mock/gomock"
-	afero "github.com/spf13/afero"
 )
 
-// MockFile is a mock of File interface.
+// MockFile is a mock of File interface
 type MockFile struct {
 	ctrl     *gomock.Controller
 	recorder *MockFileMockRecorder
 }
 
-// MockFileMockRecorder is the mock recorder for MockFile.
+// MockFileMockRecorder is the mock recorder for MockFile
 type MockFileMockRecorder struct {
 	mock *MockFile
 }
 
-// NewMockFile creates a new mock instance.
+// NewMockFile creates a new mock instance
 func NewMockFile(ctrl *gomock.Controller) *MockFile {
 	mock := &MockFile{ctrl: ctrl}
 	mock.recorder = &MockFileMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockFile) EXPECT() *MockFileMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method.
+// Close mocks base method
 func (m *MockFile) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -44,13 +43,13 @@ func (m *MockFile) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close.
+// Close indicates an expected call of Close
 func (mr *MockFileMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockFile)(nil).Close))
 }
 
-// Read mocks base method.
+// Read mocks base method
 func (m *MockFile) Read(p []byte) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Read", p)
@@ -59,13 +58,13 @@ func (m *MockFile) Read(p []byte) (int, error) {
 	return ret0, ret1
 }
 
-// Read indicates an expected call of Read.
+// Read indicates an expected call of Read
 func (mr *MockFileMockRecorder) Read(p interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockFile)(nil).Read), p)
 }
 
-// ReadAt mocks base method.
+// ReadAt mocks base method
 func (m *MockFile) ReadAt(p []byte, off int64) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadAt", p, off)
@@ -74,13 +73,13 @@ func (m *MockFile) ReadAt(p []byte, off int64) (int, error) {
 	return ret0, ret1
 }
 
-// ReadAt indicates an expected call of ReadAt.
+// ReadAt indicates an expected call of ReadAt
 func (mr *MockFileMockRecorder) ReadAt(p, off interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAt", reflect.TypeOf((*MockFile)(nil).ReadAt), p, off)
 }
 
-// Seek mocks base method.
+// Seek mocks base method
 func (m *MockFile) Seek(offset int64, whence int) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Seek", offset, whence)
@@ -89,13 +88,13 @@ func (m *MockFile) Seek(offset int64, whence int) (int64, error) {
 	return ret0, ret1
 }
 
-// Seek indicates an expected call of Seek.
+// Seek indicates an expected call of Seek
 func (mr *MockFileMockRecorder) Seek(offset, whence interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Seek", reflect.TypeOf((*MockFile)(nil).Seek), offset, whence)
 }
 
-// Write mocks base method.
+// Write mocks base method
 func (m *MockFile) Write(p []byte) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Write", p)
@@ -104,13 +103,13 @@ func (m *MockFile) Write(p []byte) (int, error) {
 	return ret0, ret1
 }
 
-// Write indicates an expected call of Write.
+// Write indicates an expected call of Write
 func (mr *MockFileMockRecorder) Write(p interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockFile)(nil).Write), p)
 }
 
-// WriteAt mocks base method.
+// WriteAt mocks base method
 func (m *MockFile) WriteAt(p []byte, off int64) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteAt", p, off)
@@ -119,13 +118,13 @@ func (m *MockFile) WriteAt(p []byte, off int64) (int, error) {
 	return ret0, ret1
 }
 
-// WriteAt indicates an expected call of WriteAt.
+// WriteAt indicates an expected call of WriteAt
 func (mr *MockFileMockRecorder) WriteAt(p, off interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteAt", reflect.TypeOf((*MockFile)(nil).WriteAt), p, off)
 }
 
-// Name mocks base method.
+// Name mocks base method
 func (m *MockFile) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -133,13 +132,13 @@ func (m *MockFile) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name.
+// Name indicates an expected call of Name
 func (mr *MockFileMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockFile)(nil).Name))
 }
 
-// Readdir mocks base method.
+// Readdir mocks base method
 func (m *MockFile) Readdir(count int) ([]os.FileInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Readdir", count)
@@ -148,13 +147,13 @@ func (m *MockFile) Readdir(count int) ([]os.FileInfo, error) {
 	return ret0, ret1
 }
 
-// Readdir indicates an expected call of Readdir.
+// Readdir indicates an expected call of Readdir
 func (mr *MockFileMockRecorder) Readdir(count interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Readdir", reflect.TypeOf((*MockFile)(nil).Readdir), count)
 }
 
-// Readdirnames mocks base method.
+// Readdirnames mocks base method
 func (m *MockFile) Readdirnames(n int) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Readdirnames", n)
@@ -163,13 +162,13 @@ func (m *MockFile) Readdirnames(n int) ([]string, error) {
 	return ret0, ret1
 }
 
-// Readdirnames indicates an expected call of Readdirnames.
+// Readdirnames indicates an expected call of Readdirnames
 func (mr *MockFileMockRecorder) Readdirnames(n interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Readdirnames", reflect.TypeOf((*MockFile)(nil).Readdirnames), n)
 }
 
-// Stat mocks base method.
+// Stat mocks base method
 func (m *MockFile) Stat() (os.FileInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stat")
@@ -178,13 +177,13 @@ func (m *MockFile) Stat() (os.FileInfo, error) {
 	return ret0, ret1
 }
 
-// Stat indicates an expected call of Stat.
+// Stat indicates an expected call of Stat
 func (mr *MockFileMockRecorder) Stat() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockFile)(nil).Stat))
 }
 
-// Sync mocks base method.
+// Sync mocks base method
 func (m *MockFile) Sync() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Sync")
@@ -192,13 +191,13 @@ func (m *MockFile) Sync() error {
 	return ret0
 }
 
-// Sync indicates an expected call of Sync.
+// Sync indicates an expected call of Sync
 func (mr *MockFileMockRecorder) Sync() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockFile)(nil).Sync))
 }
 
-// Truncate mocks base method.
+// Truncate mocks base method
 func (m *MockFile) Truncate(size int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Truncate", size)
@@ -206,13 +205,13 @@ func (m *MockFile) Truncate(size int64) error {
 	return ret0
 }
 
-// Truncate indicates an expected call of Truncate.
+// Truncate indicates an expected call of Truncate
 func (mr *MockFileMockRecorder) Truncate(size interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Truncate", reflect.TypeOf((*MockFile)(nil).Truncate), size)
 }
 
-// WriteString mocks base method.
+// WriteString mocks base method
 func (m *MockFile) WriteString(s string) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteString", s)
@@ -221,36 +220,36 @@ func (m *MockFile) WriteString(s string) (int, error) {
 	return ret0, ret1
 }
 
-// WriteString indicates an expected call of WriteString.
+// WriteString indicates an expected call of WriteString
 func (mr *MockFileMockRecorder) WriteString(s interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteString", reflect.TypeOf((*MockFile)(nil).WriteString), s)
 }
 
-// MockFs is a mock of Fs interface.
+// MockFs is a mock of Fs interface
 type MockFs struct {
 	ctrl     *gomock.Controller
 	recorder *MockFsMockRecorder
 }
 
-// MockFsMockRecorder is the mock recorder for MockFs.
+// MockFsMockRecorder is the mock recorder for MockFs
 type MockFsMockRecorder struct {
 	mock *MockFs
 }
 
-// NewMockFs creates a new mock instance.
+// NewMockFs creates a new mock instance
 func NewMockFs(ctrl *gomock.Controller) *MockFs {
 	mock := &MockFs{ctrl: ctrl}
 	mock.recorder = &MockFsMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockFs) EXPECT() *MockFsMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method.
+// Create mocks base method
 func (m *MockFs) Create(name string) (afero.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", name)
@@ -259,13 +258,13 @@ func (m *MockFs) Create(name string) (afero.File, error) {
 	return ret0, ret1
 }
 
-// Create indicates an expected call of Create.
+// Create indicates an expected call of Create
 func (mr *MockFsMockRecorder) Create(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockFs)(nil).Create), name)
 }
 
-// Mkdir mocks base method.
+// Mkdir mocks base method
 func (m *MockFs) Mkdir(name string, perm os.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Mkdir", name, perm)
@@ -273,13 +272,13 @@ func (m *MockFs) Mkdir(name string, perm os.FileMode) error {
 	return ret0
 }
 
-// Mkdir indicates an expected call of Mkdir.
+// Mkdir indicates an expected call of Mkdir
 func (mr *MockFsMockRecorder) Mkdir(name, perm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mkdir", reflect.TypeOf((*MockFs)(nil).Mkdir), name, perm)
 }
 
-// MkdirAll mocks base method.
+// MkdirAll mocks base method
 func (m *MockFs) MkdirAll(path string, perm os.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MkdirAll", path, perm)
@@ -287,13 +286,13 @@ func (m *MockFs) MkdirAll(path string, perm os.FileMode) error {
 	return ret0
 }
 
-// MkdirAll indicates an expected call of MkdirAll.
+// MkdirAll indicates an expected call of MkdirAll
 func (mr *MockFsMockRecorder) MkdirAll(path, perm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MkdirAll", reflect.TypeOf((*MockFs)(nil).MkdirAll), path, perm)
 }
 
-// Open mocks base method.
+// Open mocks base method
 func (m *MockFs) Open(name string) (afero.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Open", name)
@@ -302,13 +301,13 @@ func (m *MockFs) Open(name string) (afero.File, error) {
 	return ret0, ret1
 }
 
-// Open indicates an expected call of Open.
+// Open indicates an expected call of Open
 func (mr *MockFsMockRecorder) Open(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockFs)(nil).Open), name)
 }
 
-// OpenFile mocks base method.
+// OpenFile mocks base method
 func (m *MockFs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OpenFile", name, flag, perm)
@@ -317,13 +316,13 @@ func (m *MockFs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, 
 	return ret0, ret1
 }
 
-// OpenFile indicates an expected call of OpenFile.
+// OpenFile indicates an expected call of OpenFile
 func (mr *MockFsMockRecorder) OpenFile(name, flag, perm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenFile", reflect.TypeOf((*MockFs)(nil).OpenFile), name, flag, perm)
 }
 
-// Remove mocks base method.
+// Remove mocks base method
 func (m *MockFs) Remove(name string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Remove", name)
@@ -331,13 +330,13 @@ func (m *MockFs) Remove(name string) error {
 	return ret0
 }
 
-// Remove indicates an expected call of Remove.
+// Remove indicates an expected call of Remove
 func (mr *MockFsMockRecorder) Remove(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockFs)(nil).Remove), name)
 }
 
-// RemoveAll mocks base method.
+// RemoveAll mocks base method
 func (m *MockFs) RemoveAll(path string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAll", path)
@@ -345,13 +344,13 @@ func (m *MockFs) RemoveAll(path string) error {
 	return ret0
 }
 
-// RemoveAll indicates an expected call of RemoveAll.
+// RemoveAll indicates an expected call of RemoveAll
 func (mr *MockFsMockRecorder) RemoveAll(path interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAll", reflect.TypeOf((*MockFs)(nil).RemoveAll), path)
 }
 
-// Rename mocks base method.
+// Rename mocks base method
 func (m *MockFs) Rename(oldname, newname string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Rename", oldname, newname)
@@ -359,13 +358,13 @@ func (m *MockFs) Rename(oldname, newname string) error {
 	return ret0
 }
 
-// Rename indicates an expected call of Rename.
+// Rename indicates an expected call of Rename
 func (mr *MockFsMockRecorder) Rename(oldname, newname interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rename", reflect.TypeOf((*MockFs)(nil).Rename), oldname, newname)
 }
 
-// Stat mocks base method.
+// Stat mocks base method
 func (m *MockFs) Stat(name string) (os.FileInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stat", name)
@@ -374,13 +373,13 @@ func (m *MockFs) Stat(name string) (os.FileInfo, error) {
 	return ret0, ret1
 }
 
-// Stat indicates an expected call of Stat.
+// Stat indicates an expected call of Stat
 func (mr *MockFsMockRecorder) Stat(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockFs)(nil).Stat), name)
 }
 
-// Name mocks base method.
+// Name mocks base method
 func (m *MockFs) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -388,13 +387,13 @@ func (m *MockFs) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name.
+// Name indicates an expected call of Name
 func (mr *MockFsMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockFs)(nil).Name))
 }
 
-// Chmod mocks base method.
+// Chmod mocks base method
 func (m *MockFs) Chmod(name string, mode os.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Chmod", name, mode)
@@ -402,13 +401,13 @@ func (m *MockFs) Chmod(name string, mode os.FileMode) error {
 	return ret0
 }
 
-// Chmod indicates an expected call of Chmod.
+// Chmod indicates an expected call of Chmod
 func (mr *MockFsMockRecorder) Chmod(name, mode interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Chmod", reflect.TypeOf((*MockFs)(nil).Chmod), name, mode)
 }
 
-// Chtimes mocks base method.
+// Chtimes mocks base method
 func (m *MockFs) Chtimes(name string, atime, mtime time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Chtimes", name, atime, mtime)
@@ -416,7 +415,7 @@ func (m *MockFs) Chtimes(name string, atime, mtime time.Time) error {
 	return ret0
 }
 
-// Chtimes indicates an expected call of Chtimes.
+// Chtimes indicates an expected call of Chtimes
 func (mr *MockFsMockRecorder) Chtimes(name, atime, mtime interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Chtimes", reflect.TypeOf((*MockFs)(nil).Chtimes), name, atime, mtime)

--- a/client/internal/mocks/environment.go
+++ b/client/internal/mocks/environment.go
@@ -5,35 +5,34 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockEnvironment is a mock of Environment interface.
+// MockEnvironment is a mock of Environment interface
 type MockEnvironment struct {
 	ctrl     *gomock.Controller
 	recorder *MockEnvironmentMockRecorder
 }
 
-// MockEnvironmentMockRecorder is the mock recorder for MockEnvironment.
+// MockEnvironmentMockRecorder is the mock recorder for MockEnvironment
 type MockEnvironmentMockRecorder struct {
 	mock *MockEnvironment
 }
 
-// NewMockEnvironment creates a new mock instance.
+// NewMockEnvironment creates a new mock instance
 func NewMockEnvironment(ctrl *gomock.Controller) *MockEnvironment {
 	mock := &MockEnvironment{ctrl: ctrl}
 	mock.recorder = &MockEnvironmentMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockEnvironment) EXPECT() *MockEnvironmentMockRecorder {
 	return m.recorder
 }
 
-// Fetch mocks base method.
+// Fetch mocks base method
 func (m *MockEnvironment) Fetch() map[string]interface{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Fetch")
@@ -41,13 +40,13 @@ func (m *MockEnvironment) Fetch() map[string]interface{} {
 	return ret0
 }
 
-// Fetch indicates an expected call of Fetch.
+// Fetch indicates an expected call of Fetch
 func (mr *MockEnvironmentMockRecorder) Fetch() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fetch", reflect.TypeOf((*MockEnvironment)(nil).Fetch))
 }
 
-// Cwd mocks base method.
+// Cwd mocks base method
 func (m *MockEnvironment) Cwd() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Cwd")
@@ -56,7 +55,7 @@ func (m *MockEnvironment) Cwd() (string, error) {
 	return ret0, ret1
 }
 
-// Cwd indicates an expected call of Cwd.
+// Cwd indicates an expected call of Cwd
 func (mr *MockEnvironmentMockRecorder) Cwd() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cwd", reflect.TypeOf((*MockEnvironment)(nil).Cwd))

--- a/client/internal/mocks/info.go
+++ b/client/internal/mocks/info.go
@@ -5,37 +5,36 @@
 package mocks
 
 import (
+	gomock "github.com/golang/mock/gomock"
 	os "os"
 	reflect "reflect"
 	time "time"
-
-	gomock "github.com/golang/mock/gomock"
 )
 
-// MockInfo is a mock of Info interface.
+// MockInfo is a mock of Info interface
 type MockInfo struct {
 	ctrl     *gomock.Controller
 	recorder *MockInfoMockRecorder
 }
 
-// MockInfoMockRecorder is the mock recorder for MockInfo.
+// MockInfoMockRecorder is the mock recorder for MockInfo
 type MockInfoMockRecorder struct {
 	mock *MockInfo
 }
 
-// NewMockInfo creates a new mock instance.
+// NewMockInfo creates a new mock instance
 func NewMockInfo(ctrl *gomock.Controller) *MockInfo {
 	mock := &MockInfo{ctrl: ctrl}
 	mock.recorder = &MockInfoMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockInfo) EXPECT() *MockInfoMockRecorder {
 	return m.recorder
 }
 
-// Name mocks base method.
+// Name mocks base method
 func (m *MockInfo) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -43,13 +42,13 @@ func (m *MockInfo) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name.
+// Name indicates an expected call of Name
 func (mr *MockInfoMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockInfo)(nil).Name))
 }
 
-// Size mocks base method.
+// Size mocks base method
 func (m *MockInfo) Size() int64 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Size")
@@ -57,13 +56,13 @@ func (m *MockInfo) Size() int64 {
 	return ret0
 }
 
-// Size indicates an expected call of Size.
+// Size indicates an expected call of Size
 func (mr *MockInfoMockRecorder) Size() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockInfo)(nil).Size))
 }
 
-// Mode mocks base method.
+// Mode mocks base method
 func (m *MockInfo) Mode() os.FileMode {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Mode")
@@ -71,13 +70,13 @@ func (m *MockInfo) Mode() os.FileMode {
 	return ret0
 }
 
-// Mode indicates an expected call of Mode.
+// Mode indicates an expected call of Mode
 func (mr *MockInfoMockRecorder) Mode() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mode", reflect.TypeOf((*MockInfo)(nil).Mode))
 }
 
-// ModTime mocks base method.
+// ModTime mocks base method
 func (m *MockInfo) ModTime() time.Time {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModTime")
@@ -85,13 +84,13 @@ func (m *MockInfo) ModTime() time.Time {
 	return ret0
 }
 
-// ModTime indicates an expected call of ModTime.
+// ModTime indicates an expected call of ModTime
 func (mr *MockInfoMockRecorder) ModTime() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModTime", reflect.TypeOf((*MockInfo)(nil).ModTime))
 }
 
-// IsDir mocks base method.
+// IsDir mocks base method
 func (m *MockInfo) IsDir() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsDir")
@@ -99,13 +98,13 @@ func (m *MockInfo) IsDir() bool {
 	return ret0
 }
 
-// IsDir indicates an expected call of IsDir.
+// IsDir indicates an expected call of IsDir
 func (mr *MockInfoMockRecorder) IsDir() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDir", reflect.TypeOf((*MockInfo)(nil).IsDir))
 }
 
-// Sys mocks base method.
+// Sys mocks base method
 func (m *MockInfo) Sys() interface{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Sys")
@@ -113,7 +112,7 @@ func (m *MockInfo) Sys() interface{} {
 	return ret0
 }
 
-// Sys indicates an expected call of Sys.
+// Sys indicates an expected call of Sys
 func (mr *MockInfoMockRecorder) Sys() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sys", reflect.TypeOf((*MockInfo)(nil).Sys))

--- a/client/internal/mocks/micro/go-micro/config.go
+++ b/client/internal/mocks/micro/go-micro/config.go
@@ -5,38 +5,37 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	config "github.com/micro/go-micro/config"
 	reader "github.com/micro/go-micro/config/reader"
 	source "github.com/micro/go-micro/config/source"
+	reflect "reflect"
 )
 
-// MockConfig is a mock of Config interface.
+// MockConfig is a mock of Config interface
 type MockConfig struct {
 	ctrl     *gomock.Controller
 	recorder *MockConfigMockRecorder
 }
 
-// MockConfigMockRecorder is the mock recorder for MockConfig.
+// MockConfigMockRecorder is the mock recorder for MockConfig
 type MockConfigMockRecorder struct {
 	mock *MockConfig
 }
 
-// NewMockConfig creates a new mock instance.
+// NewMockConfig creates a new mock instance
 func NewMockConfig(ctrl *gomock.Controller) *MockConfig {
 	mock := &MockConfig{ctrl: ctrl}
 	mock.recorder = &MockConfigMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockConfig) EXPECT() *MockConfigMockRecorder {
 	return m.recorder
 }
 
-// Bytes mocks base method.
+// Bytes mocks base method
 func (m *MockConfig) Bytes() []byte {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Bytes")
@@ -44,13 +43,13 @@ func (m *MockConfig) Bytes() []byte {
 	return ret0
 }
 
-// Bytes indicates an expected call of Bytes.
+// Bytes indicates an expected call of Bytes
 func (mr *MockConfigMockRecorder) Bytes() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bytes", reflect.TypeOf((*MockConfig)(nil).Bytes))
 }
 
-// Get mocks base method.
+// Get mocks base method
 func (m *MockConfig) Get(path ...string) reader.Value {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -62,13 +61,13 @@ func (m *MockConfig) Get(path ...string) reader.Value {
 	return ret0
 }
 
-// Get indicates an expected call of Get.
+// Get indicates an expected call of Get
 func (mr *MockConfigMockRecorder) Get(path ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockConfig)(nil).Get), path...)
 }
 
-// Map mocks base method.
+// Map mocks base method
 func (m *MockConfig) Map() map[string]interface{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Map")
@@ -76,13 +75,13 @@ func (m *MockConfig) Map() map[string]interface{} {
 	return ret0
 }
 
-// Map indicates an expected call of Map.
+// Map indicates an expected call of Map
 func (mr *MockConfigMockRecorder) Map() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Map", reflect.TypeOf((*MockConfig)(nil).Map))
 }
 
-// Scan mocks base method.
+// Scan mocks base method
 func (m *MockConfig) Scan(v interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Scan", v)
@@ -90,13 +89,13 @@ func (m *MockConfig) Scan(v interface{}) error {
 	return ret0
 }
 
-// Scan indicates an expected call of Scan.
+// Scan indicates an expected call of Scan
 func (mr *MockConfigMockRecorder) Scan(v interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scan", reflect.TypeOf((*MockConfig)(nil).Scan), v)
 }
 
-// Close mocks base method.
+// Close mocks base method
 func (m *MockConfig) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -104,13 +103,13 @@ func (m *MockConfig) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close.
+// Close indicates an expected call of Close
 func (mr *MockConfigMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockConfig)(nil).Close))
 }
 
-// Load mocks base method.
+// Load mocks base method
 func (m *MockConfig) Load(source ...source.Source) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -122,13 +121,13 @@ func (m *MockConfig) Load(source ...source.Source) error {
 	return ret0
 }
 
-// Load indicates an expected call of Load.
+// Load indicates an expected call of Load
 func (mr *MockConfigMockRecorder) Load(source ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockConfig)(nil).Load), source...)
 }
 
-// Sync mocks base method.
+// Sync mocks base method
 func (m *MockConfig) Sync() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Sync")
@@ -136,13 +135,13 @@ func (m *MockConfig) Sync() error {
 	return ret0
 }
 
-// Sync indicates an expected call of Sync.
+// Sync indicates an expected call of Sync
 func (mr *MockConfigMockRecorder) Sync() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockConfig)(nil).Sync))
 }
 
-// Watch mocks base method.
+// Watch mocks base method
 func (m *MockConfig) Watch(path ...string) (config.Watcher, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -155,36 +154,36 @@ func (m *MockConfig) Watch(path ...string) (config.Watcher, error) {
 	return ret0, ret1
 }
 
-// Watch indicates an expected call of Watch.
+// Watch indicates an expected call of Watch
 func (mr *MockConfigMockRecorder) Watch(path ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockConfig)(nil).Watch), path...)
 }
 
-// MockWatcher is a mock of Watcher interface.
+// MockWatcher is a mock of Watcher interface
 type MockWatcher struct {
 	ctrl     *gomock.Controller
 	recorder *MockWatcherMockRecorder
 }
 
-// MockWatcherMockRecorder is the mock recorder for MockWatcher.
+// MockWatcherMockRecorder is the mock recorder for MockWatcher
 type MockWatcherMockRecorder struct {
 	mock *MockWatcher
 }
 
-// NewMockWatcher creates a new mock instance.
+// NewMockWatcher creates a new mock instance
 func NewMockWatcher(ctrl *gomock.Controller) *MockWatcher {
 	mock := &MockWatcher{ctrl: ctrl}
 	mock.recorder = &MockWatcherMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockWatcher) EXPECT() *MockWatcherMockRecorder {
 	return m.recorder
 }
 
-// Next mocks base method.
+// Next mocks base method
 func (m *MockWatcher) Next() (reader.Value, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Next")
@@ -193,13 +192,13 @@ func (m *MockWatcher) Next() (reader.Value, error) {
 	return ret0, ret1
 }
 
-// Next indicates an expected call of Next.
+// Next indicates an expected call of Next
 func (mr *MockWatcherMockRecorder) Next() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Next", reflect.TypeOf((*MockWatcher)(nil).Next))
 }
 
-// Stop mocks base method.
+// Stop mocks base method
 func (m *MockWatcher) Stop() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stop")
@@ -207,7 +206,7 @@ func (m *MockWatcher) Stop() error {
 	return ret0
 }
 
-// Stop indicates an expected call of Stop.
+// Stop indicates an expected call of Stop
 func (mr *MockWatcherMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockWatcher)(nil).Stop))

--- a/client/internal/mocks/micro/go-micro/reader.go
+++ b/client/internal/mocks/micro/go-micro/reader.go
@@ -5,38 +5,37 @@
 package mocks
 
 import (
+	gomock "github.com/golang/mock/gomock"
 	reader "github.com/micro/go-micro/config/reader"
+	source "github.com/micro/go-micro/config/source"
 	reflect "reflect"
 	time "time"
-
-	gomock "github.com/golang/mock/gomock"
-	source "github.com/micro/go-micro/config/source"
 )
 
-// MockReader is a mock of Reader interface.
+// MockReader is a mock of Reader interface
 type MockReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockReaderMockRecorder
 }
 
-// MockReaderMockRecorder is the mock recorder for MockReader.
+// MockReaderMockRecorder is the mock recorder for MockReader
 type MockReaderMockRecorder struct {
 	mock *MockReader
 }
 
-// NewMockReader creates a new mock instance.
+// NewMockReader creates a new mock instance
 func NewMockReader(ctrl *gomock.Controller) *MockReader {
 	mock := &MockReader{ctrl: ctrl}
 	mock.recorder = &MockReaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockReader) EXPECT() *MockReaderMockRecorder {
 	return m.recorder
 }
 
-// Merge mocks base method.
+// Merge mocks base method
 func (m *MockReader) Merge(arg0 ...*source.ChangeSet) (*source.ChangeSet, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -49,13 +48,13 @@ func (m *MockReader) Merge(arg0 ...*source.ChangeSet) (*source.ChangeSet, error)
 	return ret0, ret1
 }
 
-// Merge indicates an expected call of Merge.
+// Merge indicates an expected call of Merge
 func (mr *MockReaderMockRecorder) Merge(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Merge", reflect.TypeOf((*MockReader)(nil).Merge), arg0...)
 }
 
-// Values mocks base method.
+// Values mocks base method
 func (m *MockReader) Values(arg0 *source.ChangeSet) (reader.Values, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Values", arg0)
@@ -64,13 +63,13 @@ func (m *MockReader) Values(arg0 *source.ChangeSet) (reader.Values, error) {
 	return ret0, ret1
 }
 
-// Values indicates an expected call of Values.
+// Values indicates an expected call of Values
 func (mr *MockReaderMockRecorder) Values(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Values", reflect.TypeOf((*MockReader)(nil).Values), arg0)
 }
 
-// String mocks base method.
+// String mocks base method
 func (m *MockReader) String() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "String")
@@ -78,36 +77,36 @@ func (m *MockReader) String() string {
 	return ret0
 }
 
-// String indicates an expected call of String.
+// String indicates an expected call of String
 func (mr *MockReaderMockRecorder) String() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockReader)(nil).String))
 }
 
-// MockValues is a mock of Values interface.
+// MockValues is a mock of Values interface
 type MockValues struct {
 	ctrl     *gomock.Controller
 	recorder *MockValuesMockRecorder
 }
 
-// MockValuesMockRecorder is the mock recorder for MockValues.
+// MockValuesMockRecorder is the mock recorder for MockValues
 type MockValuesMockRecorder struct {
 	mock *MockValues
 }
 
-// NewMockValues creates a new mock instance.
+// NewMockValues creates a new mock instance
 func NewMockValues(ctrl *gomock.Controller) *MockValues {
 	mock := &MockValues{ctrl: ctrl}
 	mock.recorder = &MockValuesMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockValues) EXPECT() *MockValuesMockRecorder {
 	return m.recorder
 }
 
-// Bytes mocks base method.
+// Bytes mocks base method
 func (m *MockValues) Bytes() []byte {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Bytes")
@@ -115,13 +114,13 @@ func (m *MockValues) Bytes() []byte {
 	return ret0
 }
 
-// Bytes indicates an expected call of Bytes.
+// Bytes indicates an expected call of Bytes
 func (mr *MockValuesMockRecorder) Bytes() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bytes", reflect.TypeOf((*MockValues)(nil).Bytes))
 }
 
-// Get mocks base method.
+// Get mocks base method
 func (m *MockValues) Get(path ...string) reader.Value {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -133,13 +132,13 @@ func (m *MockValues) Get(path ...string) reader.Value {
 	return ret0
 }
 
-// Get indicates an expected call of Get.
+// Get indicates an expected call of Get
 func (mr *MockValuesMockRecorder) Get(path ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockValues)(nil).Get), path...)
 }
 
-// Map mocks base method.
+// Map mocks base method
 func (m *MockValues) Map() map[string]interface{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Map")
@@ -147,13 +146,13 @@ func (m *MockValues) Map() map[string]interface{} {
 	return ret0
 }
 
-// Map indicates an expected call of Map.
+// Map indicates an expected call of Map
 func (mr *MockValuesMockRecorder) Map() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Map", reflect.TypeOf((*MockValues)(nil).Map))
 }
 
-// Scan mocks base method.
+// Scan mocks base method
 func (m *MockValues) Scan(v interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Scan", v)
@@ -161,36 +160,36 @@ func (m *MockValues) Scan(v interface{}) error {
 	return ret0
 }
 
-// Scan indicates an expected call of Scan.
+// Scan indicates an expected call of Scan
 func (mr *MockValuesMockRecorder) Scan(v interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scan", reflect.TypeOf((*MockValues)(nil).Scan), v)
 }
 
-// MockValue is a mock of Value interface.
+// MockValue is a mock of Value interface
 type MockValue struct {
 	ctrl     *gomock.Controller
 	recorder *MockValueMockRecorder
 }
 
-// MockValueMockRecorder is the mock recorder for MockValue.
+// MockValueMockRecorder is the mock recorder for MockValue
 type MockValueMockRecorder struct {
 	mock *MockValue
 }
 
-// NewMockValue creates a new mock instance.
+// NewMockValue creates a new mock instance
 func NewMockValue(ctrl *gomock.Controller) *MockValue {
 	mock := &MockValue{ctrl: ctrl}
 	mock.recorder = &MockValueMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockValue) EXPECT() *MockValueMockRecorder {
 	return m.recorder
 }
 
-// Bool mocks base method.
+// Bool mocks base method
 func (m *MockValue) Bool(def bool) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Bool", def)
@@ -198,13 +197,13 @@ func (m *MockValue) Bool(def bool) bool {
 	return ret0
 }
 
-// Bool indicates an expected call of Bool.
+// Bool indicates an expected call of Bool
 func (mr *MockValueMockRecorder) Bool(def interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bool", reflect.TypeOf((*MockValue)(nil).Bool), def)
 }
 
-// Int mocks base method.
+// Int mocks base method
 func (m *MockValue) Int(def int) int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Int", def)
@@ -212,13 +211,13 @@ func (m *MockValue) Int(def int) int {
 	return ret0
 }
 
-// Int indicates an expected call of Int.
+// Int indicates an expected call of Int
 func (mr *MockValueMockRecorder) Int(def interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Int", reflect.TypeOf((*MockValue)(nil).Int), def)
 }
 
-// String mocks base method.
+// String mocks base method
 func (m *MockValue) String(def string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "String", def)
@@ -226,13 +225,13 @@ func (m *MockValue) String(def string) string {
 	return ret0
 }
 
-// String indicates an expected call of String.
+// String indicates an expected call of String
 func (mr *MockValueMockRecorder) String(def interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockValue)(nil).String), def)
 }
 
-// Float64 mocks base method.
+// Float64 mocks base method
 func (m *MockValue) Float64(def float64) float64 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Float64", def)
@@ -240,13 +239,13 @@ func (m *MockValue) Float64(def float64) float64 {
 	return ret0
 }
 
-// Float64 indicates an expected call of Float64.
+// Float64 indicates an expected call of Float64
 func (mr *MockValueMockRecorder) Float64(def interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Float64", reflect.TypeOf((*MockValue)(nil).Float64), def)
 }
 
-// Duration mocks base method.
+// Duration mocks base method
 func (m *MockValue) Duration(def time.Duration) time.Duration {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Duration", def)
@@ -254,13 +253,13 @@ func (m *MockValue) Duration(def time.Duration) time.Duration {
 	return ret0
 }
 
-// Duration indicates an expected call of Duration.
+// Duration indicates an expected call of Duration
 func (mr *MockValueMockRecorder) Duration(def interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Duration", reflect.TypeOf((*MockValue)(nil).Duration), def)
 }
 
-// StringSlice mocks base method.
+// StringSlice mocks base method
 func (m *MockValue) StringSlice(def []string) []string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StringSlice", def)
@@ -268,13 +267,13 @@ func (m *MockValue) StringSlice(def []string) []string {
 	return ret0
 }
 
-// StringSlice indicates an expected call of StringSlice.
+// StringSlice indicates an expected call of StringSlice
 func (mr *MockValueMockRecorder) StringSlice(def interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StringSlice", reflect.TypeOf((*MockValue)(nil).StringSlice), def)
 }
 
-// StringMap mocks base method.
+// StringMap mocks base method
 func (m *MockValue) StringMap(def map[string]string) map[string]string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StringMap", def)
@@ -282,13 +281,13 @@ func (m *MockValue) StringMap(def map[string]string) map[string]string {
 	return ret0
 }
 
-// StringMap indicates an expected call of StringMap.
+// StringMap indicates an expected call of StringMap
 func (mr *MockValueMockRecorder) StringMap(def interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StringMap", reflect.TypeOf((*MockValue)(nil).StringMap), def)
 }
 
-// Scan mocks base method.
+// Scan mocks base method
 func (m *MockValue) Scan(val interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Scan", val)
@@ -296,13 +295,13 @@ func (m *MockValue) Scan(val interface{}) error {
 	return ret0
 }
 
-// Scan indicates an expected call of Scan.
+// Scan indicates an expected call of Scan
 func (mr *MockValueMockRecorder) Scan(val interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scan", reflect.TypeOf((*MockValue)(nil).Scan), val)
 }
 
-// Bytes mocks base method.
+// Bytes mocks base method
 func (m *MockValue) Bytes() []byte {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Bytes")
@@ -310,7 +309,7 @@ func (m *MockValue) Bytes() []byte {
 	return ret0
 }
 
-// Bytes indicates an expected call of Bytes.
+// Bytes indicates an expected call of Bytes
 func (mr *MockValueMockRecorder) Bytes() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bytes", reflect.TypeOf((*MockValue)(nil).Bytes))

--- a/client/internal/mocks/mockProvider/context_provider.go
+++ b/client/internal/mocks/mockProvider/context_provider.go
@@ -5,36 +5,35 @@
 package mockProvider
 
 import (
-	reflect "reflect"
-
 	stevedore "github.com/gojek/stevedore/pkg/stevedore"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockContextProvider is a mock of ContextProvider interface.
+// MockContextProvider is a mock of ContextProvider interface
 type MockContextProvider struct {
 	ctrl     *gomock.Controller
 	recorder *MockContextProviderMockRecorder
 }
 
-// MockContextProviderMockRecorder is the mock recorder for MockContextProvider.
+// MockContextProviderMockRecorder is the mock recorder for MockContextProvider
 type MockContextProviderMockRecorder struct {
 	mock *MockContextProvider
 }
 
-// NewMockContextProvider creates a new mock instance.
+// NewMockContextProvider creates a new mock instance
 func NewMockContextProvider(ctrl *gomock.Controller) *MockContextProvider {
 	mock := &MockContextProvider{ctrl: ctrl}
 	mock.recorder = &MockContextProviderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockContextProvider) EXPECT() *MockContextProviderMockRecorder {
 	return m.recorder
 }
 
-// Context mocks base method.
+// Context mocks base method
 func (m *MockContextProvider) Context() (stevedore.Context, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
@@ -43,7 +42,7 @@ func (m *MockContextProvider) Context() (stevedore.Context, error) {
 	return ret0, ret1
 }
 
-// Context indicates an expected call of Context.
+// Context indicates an expected call of Context
 func (mr *MockContextProviderMockRecorder) Context() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockContextProvider)(nil).Context))

--- a/client/internal/mocks/mockProvider/env_provider.go
+++ b/client/internal/mocks/mockProvider/env_provider.go
@@ -5,36 +5,35 @@
 package mockProvider
 
 import (
-	reflect "reflect"
-
 	provider "github.com/gojek/stevedore/client/provider"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockEnvProvider is a mock of EnvProvider interface.
+// MockEnvProvider is a mock of EnvProvider interface
 type MockEnvProvider struct {
 	ctrl     *gomock.Controller
 	recorder *MockEnvProviderMockRecorder
 }
 
-// MockEnvProviderMockRecorder is the mock recorder for MockEnvProvider.
+// MockEnvProviderMockRecorder is the mock recorder for MockEnvProvider
 type MockEnvProviderMockRecorder struct {
 	mock *MockEnvProvider
 }
 
-// NewMockEnvProvider creates a new mock instance.
+// NewMockEnvProvider creates a new mock instance
 func NewMockEnvProvider(ctrl *gomock.Controller) *MockEnvProvider {
 	mock := &MockEnvProvider{ctrl: ctrl}
 	mock.recorder = &MockEnvProviderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockEnvProvider) EXPECT() *MockEnvProviderMockRecorder {
 	return m.recorder
 }
 
-// Envs mocks base method.
+// Envs mocks base method
 func (m *MockEnvProvider) Envs() (provider.EnvsFiles, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Envs")
@@ -43,7 +42,7 @@ func (m *MockEnvProvider) Envs() (provider.EnvsFiles, error) {
 	return ret0, ret1
 }
 
-// Envs indicates an expected call of Envs.
+// Envs indicates an expected call of Envs
 func (mr *MockEnvProviderMockRecorder) Envs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Envs", reflect.TypeOf((*MockEnvProvider)(nil).Envs))

--- a/client/internal/mocks/mockProvider/ignore_provider.go
+++ b/client/internal/mocks/mockProvider/ignore_provider.go
@@ -5,36 +5,35 @@
 package mockProvider
 
 import (
-	reflect "reflect"
-
 	stevedore "github.com/gojek/stevedore/pkg/stevedore"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockIgnoreProvider is a mock of IgnoreProvider interface.
+// MockIgnoreProvider is a mock of IgnoreProvider interface
 type MockIgnoreProvider struct {
 	ctrl     *gomock.Controller
 	recorder *MockIgnoreProviderMockRecorder
 }
 
-// MockIgnoreProviderMockRecorder is the mock recorder for MockIgnoreProvider.
+// MockIgnoreProviderMockRecorder is the mock recorder for MockIgnoreProvider
 type MockIgnoreProviderMockRecorder struct {
 	mock *MockIgnoreProvider
 }
 
-// NewMockIgnoreProvider creates a new mock instance.
+// NewMockIgnoreProvider creates a new mock instance
 func NewMockIgnoreProvider(ctrl *gomock.Controller) *MockIgnoreProvider {
 	mock := &MockIgnoreProvider{ctrl: ctrl}
 	mock.recorder = &MockIgnoreProviderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockIgnoreProvider) EXPECT() *MockIgnoreProviderMockRecorder {
 	return m.recorder
 }
 
-// Files mocks base method.
+// Files mocks base method
 func (m *MockIgnoreProvider) Files() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Files")
@@ -43,13 +42,13 @@ func (m *MockIgnoreProvider) Files() ([]string, error) {
 	return ret0, ret1
 }
 
-// Files indicates an expected call of Files.
+// Files indicates an expected call of Files
 func (mr *MockIgnoreProviderMockRecorder) Files() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Files", reflect.TypeOf((*MockIgnoreProvider)(nil).Files))
 }
 
-// Ignores mocks base method.
+// Ignores mocks base method
 func (m *MockIgnoreProvider) Ignores() (stevedore.Ignores, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Ignores")
@@ -58,7 +57,7 @@ func (m *MockIgnoreProvider) Ignores() (stevedore.Ignores, error) {
 	return ret0, ret1
 }
 
-// Ignores indicates an expected call of Ignores.
+// Ignores indicates an expected call of Ignores
 func (mr *MockIgnoreProviderMockRecorder) Ignores() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ignores", reflect.TypeOf((*MockIgnoreProvider)(nil).Ignores))

--- a/client/internal/mocks/mockProvider/override_provider.go
+++ b/client/internal/mocks/mockProvider/override_provider.go
@@ -5,36 +5,35 @@
 package mockProvider
 
 import (
-	reflect "reflect"
-
 	stevedore "github.com/gojek/stevedore/pkg/stevedore"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockOverrideProvider is a mock of OverrideProvider interface.
+// MockOverrideProvider is a mock of OverrideProvider interface
 type MockOverrideProvider struct {
 	ctrl     *gomock.Controller
 	recorder *MockOverrideProviderMockRecorder
 }
 
-// MockOverrideProviderMockRecorder is the mock recorder for MockOverrideProvider.
+// MockOverrideProviderMockRecorder is the mock recorder for MockOverrideProvider
 type MockOverrideProviderMockRecorder struct {
 	mock *MockOverrideProvider
 }
 
-// NewMockOverrideProvider creates a new mock instance.
+// NewMockOverrideProvider creates a new mock instance
 func NewMockOverrideProvider(ctrl *gomock.Controller) *MockOverrideProvider {
 	mock := &MockOverrideProvider{ctrl: ctrl}
 	mock.recorder = &MockOverrideProviderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockOverrideProvider) EXPECT() *MockOverrideProviderMockRecorder {
 	return m.recorder
 }
 
-// Overrides mocks base method.
+// Overrides mocks base method
 func (m *MockOverrideProvider) Overrides() (stevedore.Overrides, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Overrides")
@@ -43,7 +42,7 @@ func (m *MockOverrideProvider) Overrides() (stevedore.Overrides, error) {
 	return ret0, ret1
 }
 
-// Overrides indicates an expected call of Overrides.
+// Overrides indicates an expected call of Overrides
 func (mr *MockOverrideProviderMockRecorder) Overrides() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Overrides", reflect.TypeOf((*MockOverrideProvider)(nil).Overrides))

--- a/cmd/internal/mocks/afero.go
+++ b/cmd/internal/mocks/afero.go
@@ -5,38 +5,37 @@
 package mocks
 
 import (
+	gomock "github.com/golang/mock/gomock"
+	afero "github.com/spf13/afero"
 	os "os"
 	reflect "reflect"
 	time "time"
-
-	gomock "github.com/golang/mock/gomock"
-	afero "github.com/spf13/afero"
 )
 
-// MockFile is a mock of File interface.
+// MockFile is a mock of File interface
 type MockFile struct {
 	ctrl     *gomock.Controller
 	recorder *MockFileMockRecorder
 }
 
-// MockFileMockRecorder is the mock recorder for MockFile.
+// MockFileMockRecorder is the mock recorder for MockFile
 type MockFileMockRecorder struct {
 	mock *MockFile
 }
 
-// NewMockFile creates a new mock instance.
+// NewMockFile creates a new mock instance
 func NewMockFile(ctrl *gomock.Controller) *MockFile {
 	mock := &MockFile{ctrl: ctrl}
 	mock.recorder = &MockFileMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockFile) EXPECT() *MockFileMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method.
+// Close mocks base method
 func (m *MockFile) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -44,13 +43,13 @@ func (m *MockFile) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close.
+// Close indicates an expected call of Close
 func (mr *MockFileMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockFile)(nil).Close))
 }
 
-// Read mocks base method.
+// Read mocks base method
 func (m *MockFile) Read(p []byte) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Read", p)
@@ -59,13 +58,13 @@ func (m *MockFile) Read(p []byte) (int, error) {
 	return ret0, ret1
 }
 
-// Read indicates an expected call of Read.
+// Read indicates an expected call of Read
 func (mr *MockFileMockRecorder) Read(p interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockFile)(nil).Read), p)
 }
 
-// ReadAt mocks base method.
+// ReadAt mocks base method
 func (m *MockFile) ReadAt(p []byte, off int64) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadAt", p, off)
@@ -74,13 +73,13 @@ func (m *MockFile) ReadAt(p []byte, off int64) (int, error) {
 	return ret0, ret1
 }
 
-// ReadAt indicates an expected call of ReadAt.
+// ReadAt indicates an expected call of ReadAt
 func (mr *MockFileMockRecorder) ReadAt(p, off interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAt", reflect.TypeOf((*MockFile)(nil).ReadAt), p, off)
 }
 
-// Seek mocks base method.
+// Seek mocks base method
 func (m *MockFile) Seek(offset int64, whence int) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Seek", offset, whence)
@@ -89,13 +88,13 @@ func (m *MockFile) Seek(offset int64, whence int) (int64, error) {
 	return ret0, ret1
 }
 
-// Seek indicates an expected call of Seek.
+// Seek indicates an expected call of Seek
 func (mr *MockFileMockRecorder) Seek(offset, whence interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Seek", reflect.TypeOf((*MockFile)(nil).Seek), offset, whence)
 }
 
-// Write mocks base method.
+// Write mocks base method
 func (m *MockFile) Write(p []byte) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Write", p)
@@ -104,13 +103,13 @@ func (m *MockFile) Write(p []byte) (int, error) {
 	return ret0, ret1
 }
 
-// Write indicates an expected call of Write.
+// Write indicates an expected call of Write
 func (mr *MockFileMockRecorder) Write(p interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockFile)(nil).Write), p)
 }
 
-// WriteAt mocks base method.
+// WriteAt mocks base method
 func (m *MockFile) WriteAt(p []byte, off int64) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteAt", p, off)
@@ -119,13 +118,13 @@ func (m *MockFile) WriteAt(p []byte, off int64) (int, error) {
 	return ret0, ret1
 }
 
-// WriteAt indicates an expected call of WriteAt.
+// WriteAt indicates an expected call of WriteAt
 func (mr *MockFileMockRecorder) WriteAt(p, off interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteAt", reflect.TypeOf((*MockFile)(nil).WriteAt), p, off)
 }
 
-// Name mocks base method.
+// Name mocks base method
 func (m *MockFile) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -133,13 +132,13 @@ func (m *MockFile) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name.
+// Name indicates an expected call of Name
 func (mr *MockFileMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockFile)(nil).Name))
 }
 
-// Readdir mocks base method.
+// Readdir mocks base method
 func (m *MockFile) Readdir(count int) ([]os.FileInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Readdir", count)
@@ -148,13 +147,13 @@ func (m *MockFile) Readdir(count int) ([]os.FileInfo, error) {
 	return ret0, ret1
 }
 
-// Readdir indicates an expected call of Readdir.
+// Readdir indicates an expected call of Readdir
 func (mr *MockFileMockRecorder) Readdir(count interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Readdir", reflect.TypeOf((*MockFile)(nil).Readdir), count)
 }
 
-// Readdirnames mocks base method.
+// Readdirnames mocks base method
 func (m *MockFile) Readdirnames(n int) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Readdirnames", n)
@@ -163,13 +162,13 @@ func (m *MockFile) Readdirnames(n int) ([]string, error) {
 	return ret0, ret1
 }
 
-// Readdirnames indicates an expected call of Readdirnames.
+// Readdirnames indicates an expected call of Readdirnames
 func (mr *MockFileMockRecorder) Readdirnames(n interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Readdirnames", reflect.TypeOf((*MockFile)(nil).Readdirnames), n)
 }
 
-// Stat mocks base method.
+// Stat mocks base method
 func (m *MockFile) Stat() (os.FileInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stat")
@@ -178,13 +177,13 @@ func (m *MockFile) Stat() (os.FileInfo, error) {
 	return ret0, ret1
 }
 
-// Stat indicates an expected call of Stat.
+// Stat indicates an expected call of Stat
 func (mr *MockFileMockRecorder) Stat() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockFile)(nil).Stat))
 }
 
-// Sync mocks base method.
+// Sync mocks base method
 func (m *MockFile) Sync() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Sync")
@@ -192,13 +191,13 @@ func (m *MockFile) Sync() error {
 	return ret0
 }
 
-// Sync indicates an expected call of Sync.
+// Sync indicates an expected call of Sync
 func (mr *MockFileMockRecorder) Sync() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockFile)(nil).Sync))
 }
 
-// Truncate mocks base method.
+// Truncate mocks base method
 func (m *MockFile) Truncate(size int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Truncate", size)
@@ -206,13 +205,13 @@ func (m *MockFile) Truncate(size int64) error {
 	return ret0
 }
 
-// Truncate indicates an expected call of Truncate.
+// Truncate indicates an expected call of Truncate
 func (mr *MockFileMockRecorder) Truncate(size interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Truncate", reflect.TypeOf((*MockFile)(nil).Truncate), size)
 }
 
-// WriteString mocks base method.
+// WriteString mocks base method
 func (m *MockFile) WriteString(s string) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteString", s)
@@ -221,36 +220,36 @@ func (m *MockFile) WriteString(s string) (int, error) {
 	return ret0, ret1
 }
 
-// WriteString indicates an expected call of WriteString.
+// WriteString indicates an expected call of WriteString
 func (mr *MockFileMockRecorder) WriteString(s interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteString", reflect.TypeOf((*MockFile)(nil).WriteString), s)
 }
 
-// MockFs is a mock of Fs interface.
+// MockFs is a mock of Fs interface
 type MockFs struct {
 	ctrl     *gomock.Controller
 	recorder *MockFsMockRecorder
 }
 
-// MockFsMockRecorder is the mock recorder for MockFs.
+// MockFsMockRecorder is the mock recorder for MockFs
 type MockFsMockRecorder struct {
 	mock *MockFs
 }
 
-// NewMockFs creates a new mock instance.
+// NewMockFs creates a new mock instance
 func NewMockFs(ctrl *gomock.Controller) *MockFs {
 	mock := &MockFs{ctrl: ctrl}
 	mock.recorder = &MockFsMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockFs) EXPECT() *MockFsMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method.
+// Create mocks base method
 func (m *MockFs) Create(name string) (afero.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", name)
@@ -259,13 +258,13 @@ func (m *MockFs) Create(name string) (afero.File, error) {
 	return ret0, ret1
 }
 
-// Create indicates an expected call of Create.
+// Create indicates an expected call of Create
 func (mr *MockFsMockRecorder) Create(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockFs)(nil).Create), name)
 }
 
-// Mkdir mocks base method.
+// Mkdir mocks base method
 func (m *MockFs) Mkdir(name string, perm os.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Mkdir", name, perm)
@@ -273,13 +272,13 @@ func (m *MockFs) Mkdir(name string, perm os.FileMode) error {
 	return ret0
 }
 
-// Mkdir indicates an expected call of Mkdir.
+// Mkdir indicates an expected call of Mkdir
 func (mr *MockFsMockRecorder) Mkdir(name, perm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mkdir", reflect.TypeOf((*MockFs)(nil).Mkdir), name, perm)
 }
 
-// MkdirAll mocks base method.
+// MkdirAll mocks base method
 func (m *MockFs) MkdirAll(path string, perm os.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MkdirAll", path, perm)
@@ -287,13 +286,13 @@ func (m *MockFs) MkdirAll(path string, perm os.FileMode) error {
 	return ret0
 }
 
-// MkdirAll indicates an expected call of MkdirAll.
+// MkdirAll indicates an expected call of MkdirAll
 func (mr *MockFsMockRecorder) MkdirAll(path, perm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MkdirAll", reflect.TypeOf((*MockFs)(nil).MkdirAll), path, perm)
 }
 
-// Open mocks base method.
+// Open mocks base method
 func (m *MockFs) Open(name string) (afero.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Open", name)
@@ -302,13 +301,13 @@ func (m *MockFs) Open(name string) (afero.File, error) {
 	return ret0, ret1
 }
 
-// Open indicates an expected call of Open.
+// Open indicates an expected call of Open
 func (mr *MockFsMockRecorder) Open(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockFs)(nil).Open), name)
 }
 
-// OpenFile mocks base method.
+// OpenFile mocks base method
 func (m *MockFs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OpenFile", name, flag, perm)
@@ -317,13 +316,13 @@ func (m *MockFs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, 
 	return ret0, ret1
 }
 
-// OpenFile indicates an expected call of OpenFile.
+// OpenFile indicates an expected call of OpenFile
 func (mr *MockFsMockRecorder) OpenFile(name, flag, perm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenFile", reflect.TypeOf((*MockFs)(nil).OpenFile), name, flag, perm)
 }
 
-// Remove mocks base method.
+// Remove mocks base method
 func (m *MockFs) Remove(name string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Remove", name)
@@ -331,13 +330,13 @@ func (m *MockFs) Remove(name string) error {
 	return ret0
 }
 
-// Remove indicates an expected call of Remove.
+// Remove indicates an expected call of Remove
 func (mr *MockFsMockRecorder) Remove(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockFs)(nil).Remove), name)
 }
 
-// RemoveAll mocks base method.
+// RemoveAll mocks base method
 func (m *MockFs) RemoveAll(path string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAll", path)
@@ -345,13 +344,13 @@ func (m *MockFs) RemoveAll(path string) error {
 	return ret0
 }
 
-// RemoveAll indicates an expected call of RemoveAll.
+// RemoveAll indicates an expected call of RemoveAll
 func (mr *MockFsMockRecorder) RemoveAll(path interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAll", reflect.TypeOf((*MockFs)(nil).RemoveAll), path)
 }
 
-// Rename mocks base method.
+// Rename mocks base method
 func (m *MockFs) Rename(oldname, newname string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Rename", oldname, newname)
@@ -359,13 +358,13 @@ func (m *MockFs) Rename(oldname, newname string) error {
 	return ret0
 }
 
-// Rename indicates an expected call of Rename.
+// Rename indicates an expected call of Rename
 func (mr *MockFsMockRecorder) Rename(oldname, newname interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rename", reflect.TypeOf((*MockFs)(nil).Rename), oldname, newname)
 }
 
-// Stat mocks base method.
+// Stat mocks base method
 func (m *MockFs) Stat(name string) (os.FileInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stat", name)
@@ -374,13 +373,13 @@ func (m *MockFs) Stat(name string) (os.FileInfo, error) {
 	return ret0, ret1
 }
 
-// Stat indicates an expected call of Stat.
+// Stat indicates an expected call of Stat
 func (mr *MockFsMockRecorder) Stat(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockFs)(nil).Stat), name)
 }
 
-// Name mocks base method.
+// Name mocks base method
 func (m *MockFs) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -388,13 +387,13 @@ func (m *MockFs) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name.
+// Name indicates an expected call of Name
 func (mr *MockFsMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockFs)(nil).Name))
 }
 
-// Chmod mocks base method.
+// Chmod mocks base method
 func (m *MockFs) Chmod(name string, mode os.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Chmod", name, mode)
@@ -402,13 +401,13 @@ func (m *MockFs) Chmod(name string, mode os.FileMode) error {
 	return ret0
 }
 
-// Chmod indicates an expected call of Chmod.
+// Chmod indicates an expected call of Chmod
 func (mr *MockFsMockRecorder) Chmod(name, mode interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Chmod", reflect.TypeOf((*MockFs)(nil).Chmod), name, mode)
 }
 
-// Chtimes mocks base method.
+// Chtimes mocks base method
 func (m *MockFs) Chtimes(name string, atime, mtime time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Chtimes", name, atime, mtime)
@@ -416,7 +415,7 @@ func (m *MockFs) Chtimes(name string, atime, mtime time.Time) error {
 	return ret0
 }
 
-// Chtimes indicates an expected call of Chtimes.
+// Chtimes indicates an expected call of Chtimes
 func (mr *MockFsMockRecorder) Chtimes(name, atime, mtime interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Chtimes", reflect.TypeOf((*MockFs)(nil).Chtimes), name, atime, mtime)

--- a/cmd/internal/mocks/environment.go
+++ b/cmd/internal/mocks/environment.go
@@ -5,35 +5,34 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockEnvironment is a mock of Environment interface.
+// MockEnvironment is a mock of Environment interface
 type MockEnvironment struct {
 	ctrl     *gomock.Controller
 	recorder *MockEnvironmentMockRecorder
 }
 
-// MockEnvironmentMockRecorder is the mock recorder for MockEnvironment.
+// MockEnvironmentMockRecorder is the mock recorder for MockEnvironment
 type MockEnvironmentMockRecorder struct {
 	mock *MockEnvironment
 }
 
-// NewMockEnvironment creates a new mock instance.
+// NewMockEnvironment creates a new mock instance
 func NewMockEnvironment(ctrl *gomock.Controller) *MockEnvironment {
 	mock := &MockEnvironment{ctrl: ctrl}
 	mock.recorder = &MockEnvironmentMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockEnvironment) EXPECT() *MockEnvironmentMockRecorder {
 	return m.recorder
 }
 
-// Fetch mocks base method.
+// Fetch mocks base method
 func (m *MockEnvironment) Fetch() map[string]interface{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Fetch")
@@ -41,13 +40,13 @@ func (m *MockEnvironment) Fetch() map[string]interface{} {
 	return ret0
 }
 
-// Fetch indicates an expected call of Fetch.
+// Fetch indicates an expected call of Fetch
 func (mr *MockEnvironmentMockRecorder) Fetch() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fetch", reflect.TypeOf((*MockEnvironment)(nil).Fetch))
 }
 
-// Cwd mocks base method.
+// Cwd mocks base method
 func (m *MockEnvironment) Cwd() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Cwd")
@@ -56,7 +55,7 @@ func (m *MockEnvironment) Cwd() (string, error) {
 	return ret0, ret1
 }
 
-// Cwd indicates an expected call of Cwd.
+// Cwd indicates an expected call of Cwd
 func (mr *MockEnvironmentMockRecorder) Cwd() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cwd", reflect.TypeOf((*MockEnvironment)(nil).Cwd))

--- a/cmd/internal/mocks/file_utils.go
+++ b/cmd/internal/mocks/file_utils.go
@@ -5,38 +5,37 @@
 package mocks
 
 import (
+	gomock "github.com/golang/mock/gomock"
+	afero "github.com/spf13/afero"
 	os "os"
 	reflect "reflect"
 	time "time"
-
-	gomock "github.com/golang/mock/gomock"
-	afero "github.com/spf13/afero"
 )
 
-// MockFileUtils is a mock of FileUtils interface.
+// MockFileUtils is a mock of FileUtils interface
 type MockFileUtils struct {
 	ctrl     *gomock.Controller
 	recorder *MockFileUtilsMockRecorder
 }
 
-// MockFileUtilsMockRecorder is the mock recorder for MockFileUtils.
+// MockFileUtilsMockRecorder is the mock recorder for MockFileUtils
 type MockFileUtilsMockRecorder struct {
 	mock *MockFileUtils
 }
 
-// NewMockFileUtils creates a new mock instance.
+// NewMockFileUtils creates a new mock instance
 func NewMockFileUtils(ctrl *gomock.Controller) *MockFileUtils {
 	mock := &MockFileUtils{ctrl: ctrl}
 	mock.recorder = &MockFileUtilsMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockFileUtils) EXPECT() *MockFileUtilsMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method.
+// Create mocks base method
 func (m *MockFileUtils) Create(name string) (afero.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", name)
@@ -45,13 +44,13 @@ func (m *MockFileUtils) Create(name string) (afero.File, error) {
 	return ret0, ret1
 }
 
-// Create indicates an expected call of Create.
+// Create indicates an expected call of Create
 func (mr *MockFileUtilsMockRecorder) Create(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockFileUtils)(nil).Create), name)
 }
 
-// Mkdir mocks base method.
+// Mkdir mocks base method
 func (m *MockFileUtils) Mkdir(name string, perm os.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Mkdir", name, perm)
@@ -59,13 +58,13 @@ func (m *MockFileUtils) Mkdir(name string, perm os.FileMode) error {
 	return ret0
 }
 
-// Mkdir indicates an expected call of Mkdir.
+// Mkdir indicates an expected call of Mkdir
 func (mr *MockFileUtilsMockRecorder) Mkdir(name, perm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mkdir", reflect.TypeOf((*MockFileUtils)(nil).Mkdir), name, perm)
 }
 
-// MkdirAll mocks base method.
+// MkdirAll mocks base method
 func (m *MockFileUtils) MkdirAll(path string, perm os.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MkdirAll", path, perm)
@@ -73,13 +72,13 @@ func (m *MockFileUtils) MkdirAll(path string, perm os.FileMode) error {
 	return ret0
 }
 
-// MkdirAll indicates an expected call of MkdirAll.
+// MkdirAll indicates an expected call of MkdirAll
 func (mr *MockFileUtilsMockRecorder) MkdirAll(path, perm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MkdirAll", reflect.TypeOf((*MockFileUtils)(nil).MkdirAll), path, perm)
 }
 
-// Open mocks base method.
+// Open mocks base method
 func (m *MockFileUtils) Open(name string) (afero.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Open", name)
@@ -88,13 +87,13 @@ func (m *MockFileUtils) Open(name string) (afero.File, error) {
 	return ret0, ret1
 }
 
-// Open indicates an expected call of Open.
+// Open indicates an expected call of Open
 func (mr *MockFileUtilsMockRecorder) Open(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockFileUtils)(nil).Open), name)
 }
 
-// OpenFile mocks base method.
+// OpenFile mocks base method
 func (m *MockFileUtils) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OpenFile", name, flag, perm)
@@ -103,13 +102,13 @@ func (m *MockFileUtils) OpenFile(name string, flag int, perm os.FileMode) (afero
 	return ret0, ret1
 }
 
-// OpenFile indicates an expected call of OpenFile.
+// OpenFile indicates an expected call of OpenFile
 func (mr *MockFileUtilsMockRecorder) OpenFile(name, flag, perm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenFile", reflect.TypeOf((*MockFileUtils)(nil).OpenFile), name, flag, perm)
 }
 
-// Remove mocks base method.
+// Remove mocks base method
 func (m *MockFileUtils) Remove(name string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Remove", name)
@@ -117,13 +116,13 @@ func (m *MockFileUtils) Remove(name string) error {
 	return ret0
 }
 
-// Remove indicates an expected call of Remove.
+// Remove indicates an expected call of Remove
 func (mr *MockFileUtilsMockRecorder) Remove(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockFileUtils)(nil).Remove), name)
 }
 
-// RemoveAll mocks base method.
+// RemoveAll mocks base method
 func (m *MockFileUtils) RemoveAll(path string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAll", path)
@@ -131,13 +130,13 @@ func (m *MockFileUtils) RemoveAll(path string) error {
 	return ret0
 }
 
-// RemoveAll indicates an expected call of RemoveAll.
+// RemoveAll indicates an expected call of RemoveAll
 func (mr *MockFileUtilsMockRecorder) RemoveAll(path interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAll", reflect.TypeOf((*MockFileUtils)(nil).RemoveAll), path)
 }
 
-// Rename mocks base method.
+// Rename mocks base method
 func (m *MockFileUtils) Rename(oldname, newname string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Rename", oldname, newname)
@@ -145,13 +144,13 @@ func (m *MockFileUtils) Rename(oldname, newname string) error {
 	return ret0
 }
 
-// Rename indicates an expected call of Rename.
+// Rename indicates an expected call of Rename
 func (mr *MockFileUtilsMockRecorder) Rename(oldname, newname interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rename", reflect.TypeOf((*MockFileUtils)(nil).Rename), oldname, newname)
 }
 
-// Stat mocks base method.
+// Stat mocks base method
 func (m *MockFileUtils) Stat(name string) (os.FileInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stat", name)
@@ -160,13 +159,13 @@ func (m *MockFileUtils) Stat(name string) (os.FileInfo, error) {
 	return ret0, ret1
 }
 
-// Stat indicates an expected call of Stat.
+// Stat indicates an expected call of Stat
 func (mr *MockFileUtilsMockRecorder) Stat(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockFileUtils)(nil).Stat), name)
 }
 
-// Name mocks base method.
+// Name mocks base method
 func (m *MockFileUtils) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -174,13 +173,13 @@ func (m *MockFileUtils) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name.
+// Name indicates an expected call of Name
 func (mr *MockFileUtilsMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockFileUtils)(nil).Name))
 }
 
-// Chmod mocks base method.
+// Chmod mocks base method
 func (m *MockFileUtils) Chmod(name string, mode os.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Chmod", name, mode)
@@ -188,13 +187,13 @@ func (m *MockFileUtils) Chmod(name string, mode os.FileMode) error {
 	return ret0
 }
 
-// Chmod indicates an expected call of Chmod.
+// Chmod indicates an expected call of Chmod
 func (mr *MockFileUtilsMockRecorder) Chmod(name, mode interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Chmod", reflect.TypeOf((*MockFileUtils)(nil).Chmod), name, mode)
 }
 
-// Chtimes mocks base method.
+// Chtimes mocks base method
 func (m *MockFileUtils) Chtimes(name string, atime, mtime time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Chtimes", name, atime, mtime)
@@ -202,13 +201,13 @@ func (m *MockFileUtils) Chtimes(name string, atime, mtime time.Time) error {
 	return ret0
 }
 
-// Chtimes indicates an expected call of Chtimes.
+// Chtimes indicates an expected call of Chtimes
 func (mr *MockFileUtilsMockRecorder) Chtimes(name, atime, mtime interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Chtimes", reflect.TypeOf((*MockFileUtils)(nil).Chtimes), name, atime, mtime)
 }
 
-// TempDir mocks base method.
+// TempDir mocks base method
 func (m *MockFileUtils) TempDir(prefix string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TempDir", prefix)
@@ -217,13 +216,13 @@ func (m *MockFileUtils) TempDir(prefix string) (string, error) {
 	return ret0, ret1
 }
 
-// TempDir indicates an expected call of TempDir.
+// TempDir indicates an expected call of TempDir
 func (mr *MockFileUtilsMockRecorder) TempDir(prefix interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TempDir", reflect.TypeOf((*MockFileUtils)(nil).TempDir), prefix)
 }
 
-// WriteFile mocks base method.
+// WriteFile mocks base method
 func (m *MockFileUtils) WriteFile(filename string, data []byte, perm os.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteFile", filename, data, perm)
@@ -231,7 +230,7 @@ func (m *MockFileUtils) WriteFile(filename string, data []byte, perm os.FileMode
 	return ret0
 }
 
-// WriteFile indicates an expected call of WriteFile.
+// WriteFile indicates an expected call of WriteFile
 func (mr *MockFileUtilsMockRecorder) WriteFile(filename, data, perm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockFileUtils)(nil).WriteFile), filename, data, perm)

--- a/cmd/internal/mocks/info.go
+++ b/cmd/internal/mocks/info.go
@@ -5,37 +5,36 @@
 package mocks
 
 import (
+	gomock "github.com/golang/mock/gomock"
 	os "os"
 	reflect "reflect"
 	time "time"
-
-	gomock "github.com/golang/mock/gomock"
 )
 
-// MockInfo is a mock of Info interface.
+// MockInfo is a mock of Info interface
 type MockInfo struct {
 	ctrl     *gomock.Controller
 	recorder *MockInfoMockRecorder
 }
 
-// MockInfoMockRecorder is the mock recorder for MockInfo.
+// MockInfoMockRecorder is the mock recorder for MockInfo
 type MockInfoMockRecorder struct {
 	mock *MockInfo
 }
 
-// NewMockInfo creates a new mock instance.
+// NewMockInfo creates a new mock instance
 func NewMockInfo(ctrl *gomock.Controller) *MockInfo {
 	mock := &MockInfo{ctrl: ctrl}
 	mock.recorder = &MockInfoMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockInfo) EXPECT() *MockInfoMockRecorder {
 	return m.recorder
 }
 
-// Name mocks base method.
+// Name mocks base method
 func (m *MockInfo) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -43,13 +42,13 @@ func (m *MockInfo) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name.
+// Name indicates an expected call of Name
 func (mr *MockInfoMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockInfo)(nil).Name))
 }
 
-// Size mocks base method.
+// Size mocks base method
 func (m *MockInfo) Size() int64 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Size")
@@ -57,13 +56,13 @@ func (m *MockInfo) Size() int64 {
 	return ret0
 }
 
-// Size indicates an expected call of Size.
+// Size indicates an expected call of Size
 func (mr *MockInfoMockRecorder) Size() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockInfo)(nil).Size))
 }
 
-// Mode mocks base method.
+// Mode mocks base method
 func (m *MockInfo) Mode() os.FileMode {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Mode")
@@ -71,13 +70,13 @@ func (m *MockInfo) Mode() os.FileMode {
 	return ret0
 }
 
-// Mode indicates an expected call of Mode.
+// Mode indicates an expected call of Mode
 func (mr *MockInfoMockRecorder) Mode() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mode", reflect.TypeOf((*MockInfo)(nil).Mode))
 }
 
-// ModTime mocks base method.
+// ModTime mocks base method
 func (m *MockInfo) ModTime() time.Time {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModTime")
@@ -85,13 +84,13 @@ func (m *MockInfo) ModTime() time.Time {
 	return ret0
 }
 
-// ModTime indicates an expected call of ModTime.
+// ModTime indicates an expected call of ModTime
 func (mr *MockInfoMockRecorder) ModTime() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModTime", reflect.TypeOf((*MockInfo)(nil).ModTime))
 }
 
-// IsDir mocks base method.
+// IsDir mocks base method
 func (m *MockInfo) IsDir() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsDir")
@@ -99,13 +98,13 @@ func (m *MockInfo) IsDir() bool {
 	return ret0
 }
 
-// IsDir indicates an expected call of IsDir.
+// IsDir indicates an expected call of IsDir
 func (mr *MockInfoMockRecorder) IsDir() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDir", reflect.TypeOf((*MockInfo)(nil).IsDir))
 }
 
-// Sys mocks base method.
+// Sys mocks base method
 func (m *MockInfo) Sys() interface{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Sys")
@@ -113,7 +112,7 @@ func (m *MockInfo) Sys() interface{} {
 	return ret0
 }
 
-// Sys indicates an expected call of Sys.
+// Sys indicates an expected call of Sys
 func (mr *MockInfoMockRecorder) Sys() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sys", reflect.TypeOf((*MockInfo)(nil).Sys))

--- a/cmd/internal/mocks/mockManifest/provider.go
+++ b/cmd/internal/mocks/mockManifest/provider.go
@@ -5,36 +5,35 @@
 package mockManifest
 
 import (
-	reflect "reflect"
-
 	stevedore "github.com/gojek/stevedore/pkg/stevedore"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockProvider is a mock of Provider interface.
+// MockProvider is a mock of Provider interface
 type MockProvider struct {
 	ctrl     *gomock.Controller
 	recorder *MockProviderMockRecorder
 }
 
-// MockProviderMockRecorder is the mock recorder for MockProvider.
+// MockProviderMockRecorder is the mock recorder for MockProvider
 type MockProviderMockRecorder struct {
 	mock *MockProvider
 }
 
-// NewMockProvider creates a new mock instance.
+// NewMockProvider creates a new mock instance
 func NewMockProvider(ctrl *gomock.Controller) *MockProvider {
 	mock := &MockProvider{ctrl: ctrl}
 	mock.recorder = &MockProviderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 	return m.recorder
 }
 
-// Manifests mocks base method.
+// Manifests mocks base method
 func (m *MockProvider) Manifests(arg0 map[string]string) (stevedore.ManifestFiles, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Manifests", arg0)
@@ -43,7 +42,7 @@ func (m *MockProvider) Manifests(arg0 map[string]string) (stevedore.ManifestFile
 	return ret0, ret1
 }
 
-// Manifests indicates an expected call of Manifests.
+// Manifests indicates an expected call of Manifests
 func (mr *MockProviderMockRecorder) Manifests(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Manifests", reflect.TypeOf((*MockProvider)(nil).Manifests), arg0)

--- a/cmd/internal/mocks/mockManifest/reporter.go
+++ b/cmd/internal/mocks/mockManifest/reporter.go
@@ -5,103 +5,102 @@
 package mockManifest
 
 import (
-	reflect "reflect"
-
 	provider "github.com/gojek/stevedore/client/provider"
 	stevedore "github.com/gojek/stevedore/pkg/stevedore"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockReporter is a mock of Reporter interface.
+// MockReporter is a mock of Reporter interface
 type MockReporter struct {
 	ctrl     *gomock.Controller
 	recorder *MockReporterMockRecorder
 }
 
-// MockReporterMockRecorder is the mock recorder for MockReporter.
+// MockReporterMockRecorder is the mock recorder for MockReporter
 type MockReporterMockRecorder struct {
 	mock *MockReporter
 }
 
-// NewMockReporter creates a new mock instance.
+// NewMockReporter creates a new mock instance
 func NewMockReporter(ctrl *gomock.Controller) *MockReporter {
 	mock := &MockReporter{ctrl: ctrl}
 	mock.recorder = &MockReporterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockReporter) EXPECT() *MockReporterMockRecorder {
 	return m.recorder
 }
 
-// ReportContext mocks base method.
+// ReportContext mocks base method
 func (m *MockReporter) ReportContext(arg0 stevedore.Context) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ReportContext", arg0)
 }
 
-// ReportContext indicates an expected call of ReportContext.
+// ReportContext indicates an expected call of ReportContext
 func (mr *MockReporterMockRecorder) ReportContext(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportContext", reflect.TypeOf((*MockReporter)(nil).ReportContext), arg0)
 }
 
-// ReportIgnores mocks base method.
+// ReportIgnores mocks base method
 func (m *MockReporter) ReportIgnores(ignores stevedore.Ignores) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ReportIgnores", ignores)
 }
 
-// ReportIgnores indicates an expected call of ReportIgnores.
+// ReportIgnores indicates an expected call of ReportIgnores
 func (mr *MockReporterMockRecorder) ReportIgnores(ignores interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportIgnores", reflect.TypeOf((*MockReporter)(nil).ReportIgnores), ignores)
 }
 
-// ReportOverrides mocks base method.
+// ReportOverrides mocks base method
 func (m *MockReporter) ReportOverrides(overrides stevedore.Overrides) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ReportOverrides", overrides)
 }
 
-// ReportOverrides indicates an expected call of ReportOverrides.
+// ReportOverrides indicates an expected call of ReportOverrides
 func (mr *MockReporterMockRecorder) ReportOverrides(overrides interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportOverrides", reflect.TypeOf((*MockReporter)(nil).ReportOverrides), overrides)
 }
 
-// ReportManifest mocks base method.
+// ReportManifest mocks base method
 func (m *MockReporter) ReportManifest(files stevedore.ManifestFiles) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ReportManifest", files)
 }
 
-// ReportManifest indicates an expected call of ReportManifest.
+// ReportManifest indicates an expected call of ReportManifest
 func (mr *MockReporterMockRecorder) ReportManifest(files interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportManifest", reflect.TypeOf((*MockReporter)(nil).ReportManifest), files)
 }
 
-// ReportSkipped mocks base method.
+// ReportSkipped mocks base method
 func (m *MockReporter) ReportSkipped(components stevedore.IgnoredReleases) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ReportSkipped", components)
 }
 
-// ReportSkipped indicates an expected call of ReportSkipped.
+// ReportSkipped indicates an expected call of ReportSkipped
 func (mr *MockReporterMockRecorder) ReportSkipped(components interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportSkipped", reflect.TypeOf((*MockReporter)(nil).ReportSkipped), components)
 }
 
-// ReportEnvs mocks base method.
+// ReportEnvs mocks base method
 func (m *MockReporter) ReportEnvs(files provider.EnvsFiles) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ReportEnvs", files)
 }
 
-// ReportEnvs indicates an expected call of ReportEnvs.
+// ReportEnvs indicates an expected call of ReportEnvs
 func (mr *MockReporterMockRecorder) ReportEnvs(files interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportEnvs", reflect.TypeOf((*MockReporter)(nil).ReportEnvs), files)

--- a/cmd/internal/mocks/mockPlugin/types.go
+++ b/cmd/internal/mocks/mockPlugin/types.go
@@ -5,37 +5,36 @@
 package mockPlugin
 
 import (
-	reflect "reflect"
-
 	plugin "github.com/gojek/stevedore/pkg/plugin"
 	stevedore "github.com/gojek/stevedore/pkg/stevedore"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockInterface is a mock of Interface interface.
+// MockInterface is a mock of Interface interface
 type MockInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockInterfaceMockRecorder
 }
 
-// MockInterfaceMockRecorder is the mock recorder for MockInterface.
+// MockInterfaceMockRecorder is the mock recorder for MockInterface
 type MockInterfaceMockRecorder struct {
 	mock *MockInterface
 }
 
-// NewMockInterface creates a new mock instance.
+// NewMockInterface creates a new mock instance
 func NewMockInterface(ctrl *gomock.Controller) *MockInterface {
 	mock := &MockInterface{ctrl: ctrl}
 	mock.recorder = &MockInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Version mocks base method.
+// Version mocks base method
 func (m *MockInterface) Version() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Version")
@@ -44,13 +43,13 @@ func (m *MockInterface) Version() (string, error) {
 	return ret0, ret1
 }
 
-// Version indicates an expected call of Version.
+// Version indicates an expected call of Version
 func (mr *MockInterfaceMockRecorder) Version() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockInterface)(nil).Version))
 }
 
-// Flags mocks base method.
+// Flags mocks base method
 func (m *MockInterface) Flags() ([]plugin.Flag, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Flags")
@@ -59,13 +58,13 @@ func (m *MockInterface) Flags() ([]plugin.Flag, error) {
 	return ret0, ret1
 }
 
-// Flags indicates an expected call of Flags.
+// Flags indicates an expected call of Flags
 func (mr *MockInterfaceMockRecorder) Flags() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flags", reflect.TypeOf((*MockInterface)(nil).Flags))
 }
 
-// Type mocks base method.
+// Type mocks base method
 func (m *MockInterface) Type() (plugin.Type, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Type")
@@ -74,13 +73,13 @@ func (m *MockInterface) Type() (plugin.Type, error) {
 	return ret0, ret1
 }
 
-// Type indicates an expected call of Type.
+// Type indicates an expected call of Type
 func (mr *MockInterfaceMockRecorder) Type() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockInterface)(nil).Type))
 }
 
-// Help mocks base method.
+// Help mocks base method
 func (m *MockInterface) Help() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Help")
@@ -89,13 +88,13 @@ func (m *MockInterface) Help() (string, error) {
 	return ret0, ret1
 }
 
-// Help indicates an expected call of Help.
+// Help indicates an expected call of Help
 func (mr *MockInterfaceMockRecorder) Help() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Help", reflect.TypeOf((*MockInterface)(nil).Help))
 }
 
-// Close mocks base method.
+// Close mocks base method
 func (m *MockInterface) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -103,36 +102,36 @@ func (m *MockInterface) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close.
+// Close indicates an expected call of Close
 func (mr *MockInterfaceMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockInterface)(nil).Close))
 }
 
-// MockConfigInterface is a mock of ConfigInterface interface.
+// MockConfigInterface is a mock of ConfigInterface interface
 type MockConfigInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockConfigInterfaceMockRecorder
 }
 
-// MockConfigInterfaceMockRecorder is the mock recorder for MockConfigInterface.
+// MockConfigInterfaceMockRecorder is the mock recorder for MockConfigInterface
 type MockConfigInterfaceMockRecorder struct {
 	mock *MockConfigInterface
 }
 
-// NewMockConfigInterface creates a new mock instance.
+// NewMockConfigInterface creates a new mock instance
 func NewMockConfigInterface(ctrl *gomock.Controller) *MockConfigInterface {
 	mock := &MockConfigInterface{ctrl: ctrl}
 	mock.recorder = &MockConfigInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockConfigInterface) EXPECT() *MockConfigInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Version mocks base method.
+// Version mocks base method
 func (m *MockConfigInterface) Version() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Version")
@@ -141,13 +140,13 @@ func (m *MockConfigInterface) Version() (string, error) {
 	return ret0, ret1
 }
 
-// Version indicates an expected call of Version.
+// Version indicates an expected call of Version
 func (mr *MockConfigInterfaceMockRecorder) Version() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockConfigInterface)(nil).Version))
 }
 
-// Flags mocks base method.
+// Flags mocks base method
 func (m *MockConfigInterface) Flags() ([]plugin.Flag, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Flags")
@@ -156,13 +155,13 @@ func (m *MockConfigInterface) Flags() ([]plugin.Flag, error) {
 	return ret0, ret1
 }
 
-// Flags indicates an expected call of Flags.
+// Flags indicates an expected call of Flags
 func (mr *MockConfigInterfaceMockRecorder) Flags() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flags", reflect.TypeOf((*MockConfigInterface)(nil).Flags))
 }
 
-// Type mocks base method.
+// Type mocks base method
 func (m *MockConfigInterface) Type() (plugin.Type, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Type")
@@ -171,13 +170,13 @@ func (m *MockConfigInterface) Type() (plugin.Type, error) {
 	return ret0, ret1
 }
 
-// Type indicates an expected call of Type.
+// Type indicates an expected call of Type
 func (mr *MockConfigInterfaceMockRecorder) Type() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockConfigInterface)(nil).Type))
 }
 
-// Help mocks base method.
+// Help mocks base method
 func (m *MockConfigInterface) Help() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Help")
@@ -186,13 +185,13 @@ func (m *MockConfigInterface) Help() (string, error) {
 	return ret0, ret1
 }
 
-// Help indicates an expected call of Help.
+// Help indicates an expected call of Help
 func (mr *MockConfigInterfaceMockRecorder) Help() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Help", reflect.TypeOf((*MockConfigInterface)(nil).Help))
 }
 
-// Close mocks base method.
+// Close mocks base method
 func (m *MockConfigInterface) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -200,13 +199,13 @@ func (m *MockConfigInterface) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close.
+// Close indicates an expected call of Close
 func (mr *MockConfigInterfaceMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockConfigInterface)(nil).Close))
 }
 
-// Fetch mocks base method.
+// Fetch mocks base method
 func (m *MockConfigInterface) Fetch(context map[string]string, data interface{}) (map[string]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Fetch", context, data)
@@ -215,36 +214,36 @@ func (m *MockConfigInterface) Fetch(context map[string]string, data interface{})
 	return ret0, ret1
 }
 
-// Fetch indicates an expected call of Fetch.
+// Fetch indicates an expected call of Fetch
 func (mr *MockConfigInterfaceMockRecorder) Fetch(context, data interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fetch", reflect.TypeOf((*MockConfigInterface)(nil).Fetch), context, data)
 }
 
-// MockManifestInterface is a mock of ManifestInterface interface.
+// MockManifestInterface is a mock of ManifestInterface interface
 type MockManifestInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockManifestInterfaceMockRecorder
 }
 
-// MockManifestInterfaceMockRecorder is the mock recorder for MockManifestInterface.
+// MockManifestInterfaceMockRecorder is the mock recorder for MockManifestInterface
 type MockManifestInterfaceMockRecorder struct {
 	mock *MockManifestInterface
 }
 
-// NewMockManifestInterface creates a new mock instance.
+// NewMockManifestInterface creates a new mock instance
 func NewMockManifestInterface(ctrl *gomock.Controller) *MockManifestInterface {
 	mock := &MockManifestInterface{ctrl: ctrl}
 	mock.recorder = &MockManifestInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockManifestInterface) EXPECT() *MockManifestInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Version mocks base method.
+// Version mocks base method
 func (m *MockManifestInterface) Version() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Version")
@@ -253,13 +252,13 @@ func (m *MockManifestInterface) Version() (string, error) {
 	return ret0, ret1
 }
 
-// Version indicates an expected call of Version.
+// Version indicates an expected call of Version
 func (mr *MockManifestInterfaceMockRecorder) Version() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockManifestInterface)(nil).Version))
 }
 
-// Flags mocks base method.
+// Flags mocks base method
 func (m *MockManifestInterface) Flags() ([]plugin.Flag, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Flags")
@@ -268,13 +267,13 @@ func (m *MockManifestInterface) Flags() ([]plugin.Flag, error) {
 	return ret0, ret1
 }
 
-// Flags indicates an expected call of Flags.
+// Flags indicates an expected call of Flags
 func (mr *MockManifestInterfaceMockRecorder) Flags() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flags", reflect.TypeOf((*MockManifestInterface)(nil).Flags))
 }
 
-// Type mocks base method.
+// Type mocks base method
 func (m *MockManifestInterface) Type() (plugin.Type, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Type")
@@ -283,13 +282,13 @@ func (m *MockManifestInterface) Type() (plugin.Type, error) {
 	return ret0, ret1
 }
 
-// Type indicates an expected call of Type.
+// Type indicates an expected call of Type
 func (mr *MockManifestInterfaceMockRecorder) Type() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockManifestInterface)(nil).Type))
 }
 
-// Help mocks base method.
+// Help mocks base method
 func (m *MockManifestInterface) Help() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Help")
@@ -298,13 +297,13 @@ func (m *MockManifestInterface) Help() (string, error) {
 	return ret0, ret1
 }
 
-// Help indicates an expected call of Help.
+// Help indicates an expected call of Help
 func (mr *MockManifestInterfaceMockRecorder) Help() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Help", reflect.TypeOf((*MockManifestInterface)(nil).Help))
 }
 
-// Close mocks base method.
+// Close mocks base method
 func (m *MockManifestInterface) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -312,13 +311,13 @@ func (m *MockManifestInterface) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close.
+// Close indicates an expected call of Close
 func (mr *MockManifestInterfaceMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockManifestInterface)(nil).Close))
 }
 
-// Manifests mocks base method.
+// Manifests mocks base method
 func (m *MockManifestInterface) Manifests(arg0 map[string]string) (stevedore.ManifestFiles, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Manifests", arg0)
@@ -327,7 +326,7 @@ func (m *MockManifestInterface) Manifests(arg0 map[string]string) (stevedore.Man
 	return ret0, ret1
 }
 
-// Manifests indicates an expected call of Manifests.
+// Manifests indicates an expected call of Manifests
 func (mr *MockManifestInterfaceMockRecorder) Manifests(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Manifests", reflect.TypeOf((*MockManifestInterface)(nil).Manifests), arg0)

--- a/cmd/internal/mocks/mockProvider/context_provider.go
+++ b/cmd/internal/mocks/mockProvider/context_provider.go
@@ -5,36 +5,35 @@
 package mockProvider
 
 import (
-	reflect "reflect"
-
 	stevedore "github.com/gojek/stevedore/pkg/stevedore"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockContextProvider is a mock of ContextProvider interface.
+// MockContextProvider is a mock of ContextProvider interface
 type MockContextProvider struct {
 	ctrl     *gomock.Controller
 	recorder *MockContextProviderMockRecorder
 }
 
-// MockContextProviderMockRecorder is the mock recorder for MockContextProvider.
+// MockContextProviderMockRecorder is the mock recorder for MockContextProvider
 type MockContextProviderMockRecorder struct {
 	mock *MockContextProvider
 }
 
-// NewMockContextProvider creates a new mock instance.
+// NewMockContextProvider creates a new mock instance
 func NewMockContextProvider(ctrl *gomock.Controller) *MockContextProvider {
 	mock := &MockContextProvider{ctrl: ctrl}
 	mock.recorder = &MockContextProviderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockContextProvider) EXPECT() *MockContextProviderMockRecorder {
 	return m.recorder
 }
 
-// Context mocks base method.
+// Context mocks base method
 func (m *MockContextProvider) Context() (stevedore.Context, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
@@ -43,7 +42,7 @@ func (m *MockContextProvider) Context() (stevedore.Context, error) {
 	return ret0, ret1
 }
 
-// Context indicates an expected call of Context.
+// Context indicates an expected call of Context
 func (mr *MockContextProviderMockRecorder) Context() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockContextProvider)(nil).Context))

--- a/cmd/internal/mocks/mockProvider/env_provider.go
+++ b/cmd/internal/mocks/mockProvider/env_provider.go
@@ -5,36 +5,35 @@
 package mockProvider
 
 import (
-	reflect "reflect"
-
 	provider "github.com/gojek/stevedore/client/provider"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockEnvProvider is a mock of EnvProvider interface.
+// MockEnvProvider is a mock of EnvProvider interface
 type MockEnvProvider struct {
 	ctrl     *gomock.Controller
 	recorder *MockEnvProviderMockRecorder
 }
 
-// MockEnvProviderMockRecorder is the mock recorder for MockEnvProvider.
+// MockEnvProviderMockRecorder is the mock recorder for MockEnvProvider
 type MockEnvProviderMockRecorder struct {
 	mock *MockEnvProvider
 }
 
-// NewMockEnvProvider creates a new mock instance.
+// NewMockEnvProvider creates a new mock instance
 func NewMockEnvProvider(ctrl *gomock.Controller) *MockEnvProvider {
 	mock := &MockEnvProvider{ctrl: ctrl}
 	mock.recorder = &MockEnvProviderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockEnvProvider) EXPECT() *MockEnvProviderMockRecorder {
 	return m.recorder
 }
 
-// Envs mocks base method.
+// Envs mocks base method
 func (m *MockEnvProvider) Envs() (provider.EnvsFiles, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Envs")
@@ -43,7 +42,7 @@ func (m *MockEnvProvider) Envs() (provider.EnvsFiles, error) {
 	return ret0, ret1
 }
 
-// Envs indicates an expected call of Envs.
+// Envs indicates an expected call of Envs
 func (mr *MockEnvProviderMockRecorder) Envs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Envs", reflect.TypeOf((*MockEnvProvider)(nil).Envs))

--- a/cmd/internal/mocks/mockProvider/ignore_provider.go
+++ b/cmd/internal/mocks/mockProvider/ignore_provider.go
@@ -5,36 +5,35 @@
 package mockProvider
 
 import (
-	reflect "reflect"
-
 	stevedore "github.com/gojek/stevedore/pkg/stevedore"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockIgnoreProvider is a mock of IgnoreProvider interface.
+// MockIgnoreProvider is a mock of IgnoreProvider interface
 type MockIgnoreProvider struct {
 	ctrl     *gomock.Controller
 	recorder *MockIgnoreProviderMockRecorder
 }
 
-// MockIgnoreProviderMockRecorder is the mock recorder for MockIgnoreProvider.
+// MockIgnoreProviderMockRecorder is the mock recorder for MockIgnoreProvider
 type MockIgnoreProviderMockRecorder struct {
 	mock *MockIgnoreProvider
 }
 
-// NewMockIgnoreProvider creates a new mock instance.
+// NewMockIgnoreProvider creates a new mock instance
 func NewMockIgnoreProvider(ctrl *gomock.Controller) *MockIgnoreProvider {
 	mock := &MockIgnoreProvider{ctrl: ctrl}
 	mock.recorder = &MockIgnoreProviderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockIgnoreProvider) EXPECT() *MockIgnoreProviderMockRecorder {
 	return m.recorder
 }
 
-// Files mocks base method.
+// Files mocks base method
 func (m *MockIgnoreProvider) Files() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Files")
@@ -43,13 +42,13 @@ func (m *MockIgnoreProvider) Files() ([]string, error) {
 	return ret0, ret1
 }
 
-// Files indicates an expected call of Files.
+// Files indicates an expected call of Files
 func (mr *MockIgnoreProviderMockRecorder) Files() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Files", reflect.TypeOf((*MockIgnoreProvider)(nil).Files))
 }
 
-// Ignores mocks base method.
+// Ignores mocks base method
 func (m *MockIgnoreProvider) Ignores() (stevedore.Ignores, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Ignores")
@@ -58,7 +57,7 @@ func (m *MockIgnoreProvider) Ignores() (stevedore.Ignores, error) {
 	return ret0, ret1
 }
 
-// Ignores indicates an expected call of Ignores.
+// Ignores indicates an expected call of Ignores
 func (mr *MockIgnoreProviderMockRecorder) Ignores() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ignores", reflect.TypeOf((*MockIgnoreProvider)(nil).Ignores))

--- a/cmd/internal/mocks/mockProvider/override_provider.go
+++ b/cmd/internal/mocks/mockProvider/override_provider.go
@@ -5,36 +5,35 @@
 package mockProvider
 
 import (
-	reflect "reflect"
-
 	stevedore "github.com/gojek/stevedore/pkg/stevedore"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockOverrideProvider is a mock of OverrideProvider interface.
+// MockOverrideProvider is a mock of OverrideProvider interface
 type MockOverrideProvider struct {
 	ctrl     *gomock.Controller
 	recorder *MockOverrideProviderMockRecorder
 }
 
-// MockOverrideProviderMockRecorder is the mock recorder for MockOverrideProvider.
+// MockOverrideProviderMockRecorder is the mock recorder for MockOverrideProvider
 type MockOverrideProviderMockRecorder struct {
 	mock *MockOverrideProvider
 }
 
-// NewMockOverrideProvider creates a new mock instance.
+// NewMockOverrideProvider creates a new mock instance
 func NewMockOverrideProvider(ctrl *gomock.Controller) *MockOverrideProvider {
 	mock := &MockOverrideProvider{ctrl: ctrl}
 	mock.recorder = &MockOverrideProviderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockOverrideProvider) EXPECT() *MockOverrideProviderMockRecorder {
 	return m.recorder
 }
 
-// Overrides mocks base method.
+// Overrides mocks base method
 func (m *MockOverrideProvider) Overrides() (stevedore.Overrides, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Overrides")
@@ -43,7 +42,7 @@ func (m *MockOverrideProvider) Overrides() (stevedore.Overrides, error) {
 	return ret0, ret1
 }
 
-// Overrides indicates an expected call of Overrides.
+// Overrides indicates an expected call of Overrides
 func (mr *MockOverrideProviderMockRecorder) Overrides() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Overrides", reflect.TypeOf((*MockOverrideProvider)(nil).Overrides))

--- a/cmd/manifest/action.go
+++ b/cmd/manifest/action.go
@@ -9,9 +9,11 @@ type Action interface {
 func NewAction(cmd Command, info Info) Action {
 	switch cmd.name {
 	case applyCommand:
-		return NewHelmAction(info, cmd.kubeconfig, false, false, false, cmd.helmRepoName, cmd.helmTimeout)
+		return NewHelmAction(info, cmd.kubeconfig, false, false, false, cmd.helmRepoName,
+			cmd.helmTimeout, cmd.helmAtomic)
 	case planCommand:
-		return NewHelmAction(info, cmd.kubeconfig, true, true, true, cmd.helmRepoName, cmd.helmTimeout)
+		return NewHelmAction(info, cmd.kubeconfig, true, true, true, cmd.helmRepoName,
+			cmd.helmTimeout, false)
 	default:
 		return RenderAction{info: info}
 	}

--- a/cmd/manifest/command.go
+++ b/cmd/manifest/command.go
@@ -35,6 +35,8 @@ type Command struct {
 	artifactsPath      string
 	confirm            bool
 	helmTimeout        int64
+	hasHelmAtomic      bool
+	helmAtomic         bool
 }
 
 const (
@@ -54,6 +56,7 @@ func NewApplyCmd(fs afero.Fs, cfgFile *string, kubeconfigRequired bool) *Command
 		askConfirmation:    true,
 		confirm:            false,
 		kubeconfigRequired: kubeconfigRequired,
+		hasHelmAtomic:      true,
 	}
 }
 
@@ -215,6 +218,9 @@ func (actionCmd *Command) CobraCommand() (*cobra.Command, error) {
 	if actionCmd.useHelm {
 		repo.AddRepoFlags(&cmd, &actionCmd.helmRepoName)
 		cmd.PersistentFlags().Int64VarP(&actionCmd.helmTimeout, "helm-timeout", "t", 600, "Timeout in seconds(default 10 minutes)")
+		if actionCmd.hasHelmAtomic {
+			cmd.PersistentFlags().BoolVar(&actionCmd.helmAtomic, "helm-atomic", false, "Wait for resources to become ready and delete installation on failure (default: false)")
+		}
 	}
 
 	if actionCmd.kubeconfigRequired {

--- a/cmd/manifest/helm_action.go
+++ b/cmd/manifest/helm_action.go
@@ -18,13 +18,14 @@ type HelmAction struct {
 	filter       bool
 	helmRepoName string
 	helmTimeout  int64
+	helmAtomic   bool
 }
 
 type actionErrors []error
 
 // NewHelmAction returns HelmAction with given arguments
-func NewHelmAction(info Info, kubeconfig string, dryRun bool, parallel bool, filter bool, helmRepoName string, helmTimeout int64) HelmAction {
-	return HelmAction{info, kubeconfig, dryRun, parallel, filter, helmRepoName, helmTimeout}
+func NewHelmAction(info Info, kubeconfig string, dryRun bool, parallel bool, filter bool, helmRepoName string, helmTimeout int64, helmAtomic bool) HelmAction {
+	return HelmAction{info, kubeconfig, dryRun, parallel, filter, helmRepoName, helmTimeout, helmAtomic}
 }
 
 // Do will plan/apply manifests
@@ -32,7 +33,7 @@ func (action HelmAction) Do() (Info, error) {
 	manifestFiles := action.info.ManifestFiles
 	opts := stevedore.Opts{DryRun: action.dryRun, Parallel: action.parallel, Filter: action.filter}
 
-	responses, err := stevedore.CreateResponse(context.TODO(), manifestFiles, opts, action.helmRepoName, action.helmTimeout)
+	responses, err := stevedore.CreateResponse(context.TODO(), manifestFiles, opts, action.helmRepoName, action.helmTimeout, action.helmAtomic)
 
 	if err != nil {
 		return Info{}, err

--- a/examples/apps/redis.yaml
+++ b/examples/apps/redis.yaml
@@ -7,6 +7,6 @@ spec:
   - release:
       name: redis
       namespace: default
-      chart: stable/redis
+      chart: bitnami/redis
       values:
         password: ${REDIS_PASSWORD}

--- a/pkg/internal/mocks/chart/chart_builder.go
+++ b/pkg/internal/mocks/chart/chart_builder.go
@@ -6,36 +6,35 @@ package chartMocks
 
 import (
 	context "context"
-	reflect "reflect"
-
 	stevedore "github.com/gojek/stevedore/pkg/stevedore"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockChartBuilder is a mock of ChartBuilder interface.
+// MockChartBuilder is a mock of ChartBuilder interface
 type MockChartBuilder struct {
 	ctrl     *gomock.Controller
 	recorder *MockChartBuilderMockRecorder
 }
 
-// MockChartBuilderMockRecorder is the mock recorder for MockChartBuilder.
+// MockChartBuilderMockRecorder is the mock recorder for MockChartBuilder
 type MockChartBuilderMockRecorder struct {
 	mock *MockChartBuilder
 }
 
-// NewMockChartBuilder creates a new mock instance.
+// NewMockChartBuilder creates a new mock instance
 func NewMockChartBuilder(ctrl *gomock.Controller) *MockChartBuilder {
 	mock := &MockChartBuilder{ctrl: ctrl}
 	mock.recorder = &MockChartBuilderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockChartBuilder) EXPECT() *MockChartBuilderMockRecorder {
 	return m.recorder
 }
 
-// Build mocks base method.
+// Build mocks base method
 func (m *MockChartBuilder) Build(ctx context.Context, chartName, version, appVersion string, dependencies stevedore.Dependencies) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Build", ctx, chartName, version, appVersion, dependencies)
@@ -43,7 +42,7 @@ func (m *MockChartBuilder) Build(ctx context.Context, chartName, version, appVer
 	return ret0
 }
 
-// Build indicates an expected call of Build.
+// Build indicates an expected call of Build
 func (mr *MockChartBuilderMockRecorder) Build(ctx, chartName, version, appVersion, dependencies interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockChartBuilder)(nil).Build), ctx, chartName, version, appVersion, dependencies)

--- a/pkg/internal/mocks/chart/dependency_builder.go
+++ b/pkg/internal/mocks/chart/dependency_builder.go
@@ -6,36 +6,35 @@ package chartMocks
 
 import (
 	context "context"
-	reflect "reflect"
-
 	stevedore "github.com/gojek/stevedore/pkg/stevedore"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockDependencyBuilder is a mock of DependencyBuilder interface.
+// MockDependencyBuilder is a mock of DependencyBuilder interface
 type MockDependencyBuilder struct {
 	ctrl     *gomock.Controller
 	recorder *MockDependencyBuilderMockRecorder
 }
 
-// MockDependencyBuilderMockRecorder is the mock recorder for MockDependencyBuilder.
+// MockDependencyBuilderMockRecorder is the mock recorder for MockDependencyBuilder
 type MockDependencyBuilderMockRecorder struct {
 	mock *MockDependencyBuilder
 }
 
-// NewMockDependencyBuilder creates a new mock instance.
+// NewMockDependencyBuilder creates a new mock instance
 func NewMockDependencyBuilder(ctrl *gomock.Controller) *MockDependencyBuilder {
 	mock := &MockDependencyBuilder{ctrl: ctrl}
 	mock.recorder = &MockDependencyBuilderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockDependencyBuilder) EXPECT() *MockDependencyBuilderMockRecorder {
 	return m.recorder
 }
 
-// Build mocks base method.
+// Build mocks base method
 func (m *MockDependencyBuilder) Build(ctx context.Context, manifests stevedore.ManifestFiles) (stevedore.ManifestFiles, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Build", ctx, manifests)
@@ -44,13 +43,13 @@ func (m *MockDependencyBuilder) Build(ctx context.Context, manifests stevedore.M
 	return ret0, ret1
 }
 
-// Build indicates an expected call of Build.
+// Build indicates an expected call of Build
 func (mr *MockDependencyBuilderMockRecorder) Build(ctx, manifests interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockDependencyBuilder)(nil).Build), ctx, manifests)
 }
 
-// UpdateRepo mocks base method.
+// UpdateRepo mocks base method
 func (m *MockDependencyBuilder) UpdateRepo() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateRepo")
@@ -58,13 +57,13 @@ func (m *MockDependencyBuilder) UpdateRepo() error {
 	return ret0
 }
 
-// UpdateRepo indicates an expected call of UpdateRepo.
+// UpdateRepo indicates an expected call of UpdateRepo
 func (mr *MockDependencyBuilderMockRecorder) UpdateRepo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRepo", reflect.TypeOf((*MockDependencyBuilder)(nil).UpdateRepo))
 }
 
-// BuildChart mocks base method.
+// BuildChart mocks base method
 func (m *MockDependencyBuilder) BuildChart(ctx context.Context, releaseSpecification stevedore.ReleaseSpecification) (stevedore.ReleaseSpecification, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BuildChart", ctx, releaseSpecification)
@@ -74,7 +73,7 @@ func (m *MockDependencyBuilder) BuildChart(ctx context.Context, releaseSpecifica
 	return ret0, ret1, ret2
 }
 
-// BuildChart indicates an expected call of BuildChart.
+// BuildChart indicates an expected call of BuildChart
 func (mr *MockDependencyBuilderMockRecorder) BuildChart(ctx, releaseSpecification interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildChart", reflect.TypeOf((*MockDependencyBuilder)(nil).BuildChart), ctx, releaseSpecification)

--- a/pkg/internal/mocks/chart_manager.go
+++ b/pkg/internal/mocks/chart_manager.go
@@ -6,36 +6,35 @@ package mocks
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	chart "helm.sh/helm/v3/pkg/chart"
+	reflect "reflect"
 )
 
-// MockChartManager is a mock of ChartManager interface.
+// MockChartManager is a mock of ChartManager interface
 type MockChartManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockChartManagerMockRecorder
 }
 
-// MockChartManagerMockRecorder is the mock recorder for MockChartManager.
+// MockChartManagerMockRecorder is the mock recorder for MockChartManager
 type MockChartManagerMockRecorder struct {
 	mock *MockChartManager
 }
 
-// NewMockChartManager creates a new mock instance.
+// NewMockChartManager creates a new mock instance
 func NewMockChartManager(ctrl *gomock.Controller) *MockChartManager {
 	mock := &MockChartManager{ctrl: ctrl}
 	mock.recorder = &MockChartManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockChartManager) EXPECT() *MockChartManagerMockRecorder {
 	return m.recorder
 }
 
-// Build mocks base method.
+// Build mocks base method
 func (m *MockChartManager) Build(ctx context.Context, chartPath string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Build", ctx, chartPath)
@@ -43,13 +42,13 @@ func (m *MockChartManager) Build(ctx context.Context, chartPath string) error {
 	return ret0
 }
 
-// Build indicates an expected call of Build.
+// Build indicates an expected call of Build
 func (mr *MockChartManagerMockRecorder) Build(ctx, chartPath interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockChartManager)(nil).Build), ctx, chartPath)
 }
 
-// Load mocks base method.
+// Load mocks base method
 func (m *MockChartManager) Load(ctx context.Context, chartPath string) (*chart.Chart, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Load", ctx, chartPath)
@@ -58,13 +57,13 @@ func (m *MockChartManager) Load(ctx context.Context, chartPath string) (*chart.C
 	return ret0, ret1
 }
 
-// Load indicates an expected call of Load.
+// Load indicates an expected call of Load
 func (mr *MockChartManagerMockRecorder) Load(ctx, chartPath interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockChartManager)(nil).Load), ctx, chartPath)
 }
 
-// Archive mocks base method.
+// Archive mocks base method
 func (m *MockChartManager) Archive(ctx context.Context, ch *chart.Chart, outDir string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Archive", ctx, ch, outDir)
@@ -73,13 +72,13 @@ func (m *MockChartManager) Archive(ctx context.Context, ch *chart.Chart, outDir 
 	return ret0, ret1
 }
 
-// Archive indicates an expected call of Archive.
+// Archive indicates an expected call of Archive
 func (mr *MockChartManagerMockRecorder) Archive(ctx, ch, outDir interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Archive", reflect.TypeOf((*MockChartManager)(nil).Archive), ctx, ch, outDir)
 }
 
-// UploadChart mocks base method.
+// UploadChart mocks base method
 func (m *MockChartManager) UploadChart(ctx context.Context, name, url string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UploadChart", ctx, name, url)
@@ -87,7 +86,7 @@ func (m *MockChartManager) UploadChart(ctx context.Context, name, url string) er
 	return ret0
 }
 
-// UploadChart indicates an expected call of UploadChart.
+// UploadChart indicates an expected call of UploadChart
 func (mr *MockChartManagerMockRecorder) UploadChart(ctx, name, url interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadChart", reflect.TypeOf((*MockChartManager)(nil).UploadChart), ctx, name, url)

--- a/pkg/internal/mocks/file_utils.go
+++ b/pkg/internal/mocks/file_utils.go
@@ -5,38 +5,37 @@
 package mocks
 
 import (
+	gomock "github.com/golang/mock/gomock"
+	afero "github.com/spf13/afero"
 	os "os"
 	reflect "reflect"
 	time "time"
-
-	gomock "github.com/golang/mock/gomock"
-	afero "github.com/spf13/afero"
 )
 
-// MockFileUtils is a mock of FileUtils interface.
+// MockFileUtils is a mock of FileUtils interface
 type MockFileUtils struct {
 	ctrl     *gomock.Controller
 	recorder *MockFileUtilsMockRecorder
 }
 
-// MockFileUtilsMockRecorder is the mock recorder for MockFileUtils.
+// MockFileUtilsMockRecorder is the mock recorder for MockFileUtils
 type MockFileUtilsMockRecorder struct {
 	mock *MockFileUtils
 }
 
-// NewMockFileUtils creates a new mock instance.
+// NewMockFileUtils creates a new mock instance
 func NewMockFileUtils(ctrl *gomock.Controller) *MockFileUtils {
 	mock := &MockFileUtils{ctrl: ctrl}
 	mock.recorder = &MockFileUtilsMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockFileUtils) EXPECT() *MockFileUtilsMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method.
+// Create mocks base method
 func (m *MockFileUtils) Create(name string) (afero.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", name)
@@ -45,13 +44,13 @@ func (m *MockFileUtils) Create(name string) (afero.File, error) {
 	return ret0, ret1
 }
 
-// Create indicates an expected call of Create.
+// Create indicates an expected call of Create
 func (mr *MockFileUtilsMockRecorder) Create(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockFileUtils)(nil).Create), name)
 }
 
-// Mkdir mocks base method.
+// Mkdir mocks base method
 func (m *MockFileUtils) Mkdir(name string, perm os.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Mkdir", name, perm)
@@ -59,13 +58,13 @@ func (m *MockFileUtils) Mkdir(name string, perm os.FileMode) error {
 	return ret0
 }
 
-// Mkdir indicates an expected call of Mkdir.
+// Mkdir indicates an expected call of Mkdir
 func (mr *MockFileUtilsMockRecorder) Mkdir(name, perm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mkdir", reflect.TypeOf((*MockFileUtils)(nil).Mkdir), name, perm)
 }
 
-// MkdirAll mocks base method.
+// MkdirAll mocks base method
 func (m *MockFileUtils) MkdirAll(path string, perm os.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MkdirAll", path, perm)
@@ -73,13 +72,13 @@ func (m *MockFileUtils) MkdirAll(path string, perm os.FileMode) error {
 	return ret0
 }
 
-// MkdirAll indicates an expected call of MkdirAll.
+// MkdirAll indicates an expected call of MkdirAll
 func (mr *MockFileUtilsMockRecorder) MkdirAll(path, perm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MkdirAll", reflect.TypeOf((*MockFileUtils)(nil).MkdirAll), path, perm)
 }
 
-// Open mocks base method.
+// Open mocks base method
 func (m *MockFileUtils) Open(name string) (afero.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Open", name)
@@ -88,13 +87,13 @@ func (m *MockFileUtils) Open(name string) (afero.File, error) {
 	return ret0, ret1
 }
 
-// Open indicates an expected call of Open.
+// Open indicates an expected call of Open
 func (mr *MockFileUtilsMockRecorder) Open(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockFileUtils)(nil).Open), name)
 }
 
-// OpenFile mocks base method.
+// OpenFile mocks base method
 func (m *MockFileUtils) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OpenFile", name, flag, perm)
@@ -103,13 +102,13 @@ func (m *MockFileUtils) OpenFile(name string, flag int, perm os.FileMode) (afero
 	return ret0, ret1
 }
 
-// OpenFile indicates an expected call of OpenFile.
+// OpenFile indicates an expected call of OpenFile
 func (mr *MockFileUtilsMockRecorder) OpenFile(name, flag, perm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenFile", reflect.TypeOf((*MockFileUtils)(nil).OpenFile), name, flag, perm)
 }
 
-// Remove mocks base method.
+// Remove mocks base method
 func (m *MockFileUtils) Remove(name string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Remove", name)
@@ -117,13 +116,13 @@ func (m *MockFileUtils) Remove(name string) error {
 	return ret0
 }
 
-// Remove indicates an expected call of Remove.
+// Remove indicates an expected call of Remove
 func (mr *MockFileUtilsMockRecorder) Remove(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockFileUtils)(nil).Remove), name)
 }
 
-// RemoveAll mocks base method.
+// RemoveAll mocks base method
 func (m *MockFileUtils) RemoveAll(path string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAll", path)
@@ -131,13 +130,13 @@ func (m *MockFileUtils) RemoveAll(path string) error {
 	return ret0
 }
 
-// RemoveAll indicates an expected call of RemoveAll.
+// RemoveAll indicates an expected call of RemoveAll
 func (mr *MockFileUtilsMockRecorder) RemoveAll(path interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAll", reflect.TypeOf((*MockFileUtils)(nil).RemoveAll), path)
 }
 
-// Rename mocks base method.
+// Rename mocks base method
 func (m *MockFileUtils) Rename(oldname, newname string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Rename", oldname, newname)
@@ -145,13 +144,13 @@ func (m *MockFileUtils) Rename(oldname, newname string) error {
 	return ret0
 }
 
-// Rename indicates an expected call of Rename.
+// Rename indicates an expected call of Rename
 func (mr *MockFileUtilsMockRecorder) Rename(oldname, newname interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rename", reflect.TypeOf((*MockFileUtils)(nil).Rename), oldname, newname)
 }
 
-// Stat mocks base method.
+// Stat mocks base method
 func (m *MockFileUtils) Stat(name string) (os.FileInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stat", name)
@@ -160,13 +159,13 @@ func (m *MockFileUtils) Stat(name string) (os.FileInfo, error) {
 	return ret0, ret1
 }
 
-// Stat indicates an expected call of Stat.
+// Stat indicates an expected call of Stat
 func (mr *MockFileUtilsMockRecorder) Stat(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockFileUtils)(nil).Stat), name)
 }
 
-// Name mocks base method.
+// Name mocks base method
 func (m *MockFileUtils) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -174,13 +173,13 @@ func (m *MockFileUtils) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name.
+// Name indicates an expected call of Name
 func (mr *MockFileUtilsMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockFileUtils)(nil).Name))
 }
 
-// Chmod mocks base method.
+// Chmod mocks base method
 func (m *MockFileUtils) Chmod(name string, mode os.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Chmod", name, mode)
@@ -188,13 +187,13 @@ func (m *MockFileUtils) Chmod(name string, mode os.FileMode) error {
 	return ret0
 }
 
-// Chmod indicates an expected call of Chmod.
+// Chmod indicates an expected call of Chmod
 func (mr *MockFileUtilsMockRecorder) Chmod(name, mode interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Chmod", reflect.TypeOf((*MockFileUtils)(nil).Chmod), name, mode)
 }
 
-// Chtimes mocks base method.
+// Chtimes mocks base method
 func (m *MockFileUtils) Chtimes(name string, atime, mtime time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Chtimes", name, atime, mtime)
@@ -202,13 +201,13 @@ func (m *MockFileUtils) Chtimes(name string, atime, mtime time.Time) error {
 	return ret0
 }
 
-// Chtimes indicates an expected call of Chtimes.
+// Chtimes indicates an expected call of Chtimes
 func (mr *MockFileUtilsMockRecorder) Chtimes(name, atime, mtime interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Chtimes", reflect.TypeOf((*MockFileUtils)(nil).Chtimes), name, atime, mtime)
 }
 
-// TempDir mocks base method.
+// TempDir mocks base method
 func (m *MockFileUtils) TempDir(prefix string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TempDir", prefix)
@@ -217,13 +216,13 @@ func (m *MockFileUtils) TempDir(prefix string) (string, error) {
 	return ret0, ret1
 }
 
-// TempDir indicates an expected call of TempDir.
+// TempDir indicates an expected call of TempDir
 func (mr *MockFileUtilsMockRecorder) TempDir(prefix interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TempDir", reflect.TypeOf((*MockFileUtils)(nil).TempDir), prefix)
 }
 
-// WriteFile mocks base method.
+// WriteFile mocks base method
 func (m *MockFileUtils) WriteFile(filename string, data []byte, perm os.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteFile", filename, data, perm)
@@ -231,7 +230,7 @@ func (m *MockFileUtils) WriteFile(filename string, data []byte, perm os.FileMode
 	return ret0
 }
 
-// WriteFile indicates an expected call of WriteFile.
+// WriteFile indicates an expected call of WriteFile
 func (mr *MockFileUtilsMockRecorder) WriteFile(filename, data, perm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockFileUtils)(nil).WriteFile), filename, data, perm)

--- a/pkg/internal/mocks/helm/client.go
+++ b/pkg/internal/mocks/helm/client.go
@@ -35,16 +35,16 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // Upstall mocks base method
-func (m *MockClient) Upstall(ctx context.Context, releaseName, chartName, chartVersion string, plannedReleaseVersion int32, namespace, values string, dryRun bool, timeout int64) (helm.UpstallResponse, error) {
+func (m *MockClient) Upstall(ctx context.Context, releaseName, chartName, chartVersion string, plannedReleaseVersion int32, namespace, values string, dryRun bool, timeout int64, atomic bool) (helm.UpstallResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upstall", ctx, releaseName, chartName, chartVersion, plannedReleaseVersion, namespace, values, dryRun, timeout)
+	ret := m.ctrl.Call(m, "Upstall", ctx, releaseName, chartName, chartVersion, plannedReleaseVersion, namespace, values, dryRun, timeout, atomic)
 	ret0, _ := ret[0].(helm.UpstallResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Upstall indicates an expected call of Upstall
-func (mr *MockClientMockRecorder) Upstall(ctx, releaseName, chartName, chartVersion, plannedReleaseVersion, namespace, values, dryRun, timeout interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) Upstall(ctx, releaseName, chartName, chartVersion, plannedReleaseVersion, namespace, values, dryRun, timeout, atomic interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upstall", reflect.TypeOf((*MockClient)(nil).Upstall), ctx, releaseName, chartName, chartVersion, plannedReleaseVersion, namespace, values, dryRun, timeout)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upstall", reflect.TypeOf((*MockClient)(nil).Upstall), ctx, releaseName, chartName, chartVersion, plannedReleaseVersion, namespace, values, dryRun, timeout, atomic)
 }

--- a/pkg/internal/mocks/helm/helm.go
+++ b/pkg/internal/mocks/helm/helm.go
@@ -5,36 +5,35 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	provenance "helm.sh/helm/v3/pkg/provenance"
+	reflect "reflect"
 )
 
-// MockChartDownloader is a mock of ChartDownloader interface.
+// MockChartDownloader is a mock of ChartDownloader interface
 type MockChartDownloader struct {
 	ctrl     *gomock.Controller
 	recorder *MockChartDownloaderMockRecorder
 }
 
-// MockChartDownloaderMockRecorder is the mock recorder for MockChartDownloader.
+// MockChartDownloaderMockRecorder is the mock recorder for MockChartDownloader
 type MockChartDownloaderMockRecorder struct {
 	mock *MockChartDownloader
 }
 
-// NewMockChartDownloader creates a new mock instance.
+// NewMockChartDownloader creates a new mock instance
 func NewMockChartDownloader(ctrl *gomock.Controller) *MockChartDownloader {
 	mock := &MockChartDownloader{ctrl: ctrl}
 	mock.recorder = &MockChartDownloaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockChartDownloader) EXPECT() *MockChartDownloaderMockRecorder {
 	return m.recorder
 }
 
-// DownloadTo mocks base method.
+// DownloadTo mocks base method
 func (m *MockChartDownloader) DownloadTo(ref, version, dest string) (string, *provenance.Verification, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadTo", ref, version, dest)
@@ -44,36 +43,36 @@ func (m *MockChartDownloader) DownloadTo(ref, version, dest string) (string, *pr
 	return ret0, ret1, ret2
 }
 
-// DownloadTo indicates an expected call of DownloadTo.
+// DownloadTo indicates an expected call of DownloadTo
 func (mr *MockChartDownloaderMockRecorder) DownloadTo(ref, version, dest interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadTo", reflect.TypeOf((*MockChartDownloader)(nil).DownloadTo), ref, version, dest)
 }
 
-// MockChartVerifier is a mock of ChartVerifier interface.
+// MockChartVerifier is a mock of ChartVerifier interface
 type MockChartVerifier struct {
 	ctrl     *gomock.Controller
 	recorder *MockChartVerifierMockRecorder
 }
 
-// MockChartVerifierMockRecorder is the mock recorder for MockChartVerifier.
+// MockChartVerifierMockRecorder is the mock recorder for MockChartVerifier
 type MockChartVerifierMockRecorder struct {
 	mock *MockChartVerifier
 }
 
-// NewMockChartVerifier creates a new mock instance.
+// NewMockChartVerifier creates a new mock instance
 func NewMockChartVerifier(ctrl *gomock.Controller) *MockChartVerifier {
 	mock := &MockChartVerifier{ctrl: ctrl}
 	mock.recorder = &MockChartVerifierMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockChartVerifier) EXPECT() *MockChartVerifierMockRecorder {
 	return m.recorder
 }
 
-// VerifyChart mocks base method.
+// VerifyChart mocks base method
 func (m *MockChartVerifier) VerifyChart(path, keyring string) (*provenance.Verification, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyChart", path, keyring)
@@ -82,7 +81,7 @@ func (m *MockChartVerifier) VerifyChart(path, keyring string) (*provenance.Verif
 	return ret0, ret1
 }
 
-// VerifyChart indicates an expected call of VerifyChart.
+// VerifyChart indicates an expected call of VerifyChart
 func (mr *MockChartVerifierMockRecorder) VerifyChart(path, keyring interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyChart", reflect.TypeOf((*MockChartVerifier)(nil).VerifyChart), path, keyring)

--- a/pkg/internal/mocks/http/client.go
+++ b/pkg/internal/mocks/http/client.go
@@ -5,36 +5,35 @@
 package mocks
 
 import (
+	gomock "github.com/golang/mock/gomock"
 	http "net/http"
 	reflect "reflect"
-
-	gomock "github.com/golang/mock/gomock"
 )
 
-// MockClient is a mock of Client interface.
+// MockClient is a mock of Client interface
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient.
+// MockClientMockRecorder is the mock recorder for MockClient
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance.
+// NewMockClient creates a new mock instance
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method.
+// Get mocks base method
 func (m *MockClient) Get(url string) (*http.Response, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", url)
@@ -43,13 +42,13 @@ func (m *MockClient) Get(url string) (*http.Response, error) {
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get.
+// Get indicates an expected call of Get
 func (mr *MockClientMockRecorder) Get(url interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockClient)(nil).Get), url)
 }
 
-// Do mocks base method.
+// Do mocks base method
 func (m *MockClient) Do(req *http.Request) (*http.Response, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Do", req)
@@ -58,7 +57,7 @@ func (m *MockClient) Do(req *http.Request) (*http.Response, error) {
 	return ret0, ret1
 }
 
-// Do indicates an expected call of Do.
+// Do indicates an expected call of Do
 func (mr *MockClientMockRecorder) Do(req interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Do", reflect.TypeOf((*MockClient)(nil).Do), req)

--- a/pkg/internal/mocks/os/file_utils.go
+++ b/pkg/internal/mocks/os/file_utils.go
@@ -5,37 +5,36 @@
 package mock_os
 
 import (
+	gomock "github.com/golang/mock/gomock"
 	os "os"
 	reflect "reflect"
 	time "time"
-
-	gomock "github.com/golang/mock/gomock"
 )
 
-// MockFileInfo is a mock of FileInfo interface.
+// MockFileInfo is a mock of FileInfo interface
 type MockFileInfo struct {
 	ctrl     *gomock.Controller
 	recorder *MockFileInfoMockRecorder
 }
 
-// MockFileInfoMockRecorder is the mock recorder for MockFileInfo.
+// MockFileInfoMockRecorder is the mock recorder for MockFileInfo
 type MockFileInfoMockRecorder struct {
 	mock *MockFileInfo
 }
 
-// NewMockFileInfo creates a new mock instance.
+// NewMockFileInfo creates a new mock instance
 func NewMockFileInfo(ctrl *gomock.Controller) *MockFileInfo {
 	mock := &MockFileInfo{ctrl: ctrl}
 	mock.recorder = &MockFileInfoMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockFileInfo) EXPECT() *MockFileInfoMockRecorder {
 	return m.recorder
 }
 
-// IsDir mocks base method.
+// IsDir mocks base method
 func (m *MockFileInfo) IsDir() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsDir")
@@ -43,13 +42,13 @@ func (m *MockFileInfo) IsDir() bool {
 	return ret0
 }
 
-// IsDir indicates an expected call of IsDir.
+// IsDir indicates an expected call of IsDir
 func (mr *MockFileInfoMockRecorder) IsDir() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDir", reflect.TypeOf((*MockFileInfo)(nil).IsDir))
 }
 
-// ModTime mocks base method.
+// ModTime mocks base method
 func (m *MockFileInfo) ModTime() time.Time {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModTime")
@@ -57,13 +56,13 @@ func (m *MockFileInfo) ModTime() time.Time {
 	return ret0
 }
 
-// ModTime indicates an expected call of ModTime.
+// ModTime indicates an expected call of ModTime
 func (mr *MockFileInfoMockRecorder) ModTime() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModTime", reflect.TypeOf((*MockFileInfo)(nil).ModTime))
 }
 
-// Mode mocks base method.
+// Mode mocks base method
 func (m *MockFileInfo) Mode() os.FileMode {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Mode")
@@ -71,13 +70,13 @@ func (m *MockFileInfo) Mode() os.FileMode {
 	return ret0
 }
 
-// Mode indicates an expected call of Mode.
+// Mode indicates an expected call of Mode
 func (mr *MockFileInfoMockRecorder) Mode() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mode", reflect.TypeOf((*MockFileInfo)(nil).Mode))
 }
 
-// Name mocks base method.
+// Name mocks base method
 func (m *MockFileInfo) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -85,13 +84,13 @@ func (m *MockFileInfo) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name.
+// Name indicates an expected call of Name
 func (mr *MockFileInfoMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockFileInfo)(nil).Name))
 }
 
-// Size mocks base method.
+// Size mocks base method
 func (m *MockFileInfo) Size() int64 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Size")
@@ -99,13 +98,13 @@ func (m *MockFileInfo) Size() int64 {
 	return ret0
 }
 
-// Size indicates an expected call of Size.
+// Size indicates an expected call of Size
 func (mr *MockFileInfoMockRecorder) Size() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockFileInfo)(nil).Size))
 }
 
-// Sys mocks base method.
+// Sys mocks base method
 func (m *MockFileInfo) Sys() interface{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Sys")
@@ -113,7 +112,7 @@ func (m *MockFileInfo) Sys() interface{} {
 	return ret0
 }
 
-// Sys indicates an expected call of Sys.
+// Sys indicates an expected call of Sys
 func (mr *MockFileInfoMockRecorder) Sys() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sys", reflect.TypeOf((*MockFileInfo)(nil).Sys))

--- a/pkg/internal/mocks/plugin/types.go
+++ b/pkg/internal/mocks/plugin/types.go
@@ -5,37 +5,36 @@
 package mockPlugin
 
 import (
-	reflect "reflect"
-
 	plugin "github.com/gojek/stevedore/pkg/plugin"
 	stevedore "github.com/gojek/stevedore/pkg/stevedore"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockInterface is a mock of Interface interface.
+// MockInterface is a mock of Interface interface
 type MockInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockInterfaceMockRecorder
 }
 
-// MockInterfaceMockRecorder is the mock recorder for MockInterface.
+// MockInterfaceMockRecorder is the mock recorder for MockInterface
 type MockInterfaceMockRecorder struct {
 	mock *MockInterface
 }
 
-// NewMockInterface creates a new mock instance.
+// NewMockInterface creates a new mock instance
 func NewMockInterface(ctrl *gomock.Controller) *MockInterface {
 	mock := &MockInterface{ctrl: ctrl}
 	mock.recorder = &MockInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Version mocks base method.
+// Version mocks base method
 func (m *MockInterface) Version() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Version")
@@ -44,13 +43,13 @@ func (m *MockInterface) Version() (string, error) {
 	return ret0, ret1
 }
 
-// Version indicates an expected call of Version.
+// Version indicates an expected call of Version
 func (mr *MockInterfaceMockRecorder) Version() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockInterface)(nil).Version))
 }
 
-// Flags mocks base method.
+// Flags mocks base method
 func (m *MockInterface) Flags() ([]plugin.Flag, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Flags")
@@ -59,13 +58,13 @@ func (m *MockInterface) Flags() ([]plugin.Flag, error) {
 	return ret0, ret1
 }
 
-// Flags indicates an expected call of Flags.
+// Flags indicates an expected call of Flags
 func (mr *MockInterfaceMockRecorder) Flags() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flags", reflect.TypeOf((*MockInterface)(nil).Flags))
 }
 
-// Type mocks base method.
+// Type mocks base method
 func (m *MockInterface) Type() (plugin.Type, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Type")
@@ -74,13 +73,13 @@ func (m *MockInterface) Type() (plugin.Type, error) {
 	return ret0, ret1
 }
 
-// Type indicates an expected call of Type.
+// Type indicates an expected call of Type
 func (mr *MockInterfaceMockRecorder) Type() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockInterface)(nil).Type))
 }
 
-// Help mocks base method.
+// Help mocks base method
 func (m *MockInterface) Help() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Help")
@@ -89,13 +88,13 @@ func (m *MockInterface) Help() (string, error) {
 	return ret0, ret1
 }
 
-// Help indicates an expected call of Help.
+// Help indicates an expected call of Help
 func (mr *MockInterfaceMockRecorder) Help() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Help", reflect.TypeOf((*MockInterface)(nil).Help))
 }
 
-// Close mocks base method.
+// Close mocks base method
 func (m *MockInterface) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -103,36 +102,36 @@ func (m *MockInterface) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close.
+// Close indicates an expected call of Close
 func (mr *MockInterfaceMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockInterface)(nil).Close))
 }
 
-// MockConfigInterface is a mock of ConfigInterface interface.
+// MockConfigInterface is a mock of ConfigInterface interface
 type MockConfigInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockConfigInterfaceMockRecorder
 }
 
-// MockConfigInterfaceMockRecorder is the mock recorder for MockConfigInterface.
+// MockConfigInterfaceMockRecorder is the mock recorder for MockConfigInterface
 type MockConfigInterfaceMockRecorder struct {
 	mock *MockConfigInterface
 }
 
-// NewMockConfigInterface creates a new mock instance.
+// NewMockConfigInterface creates a new mock instance
 func NewMockConfigInterface(ctrl *gomock.Controller) *MockConfigInterface {
 	mock := &MockConfigInterface{ctrl: ctrl}
 	mock.recorder = &MockConfigInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockConfigInterface) EXPECT() *MockConfigInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Version mocks base method.
+// Version mocks base method
 func (m *MockConfigInterface) Version() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Version")
@@ -141,13 +140,13 @@ func (m *MockConfigInterface) Version() (string, error) {
 	return ret0, ret1
 }
 
-// Version indicates an expected call of Version.
+// Version indicates an expected call of Version
 func (mr *MockConfigInterfaceMockRecorder) Version() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockConfigInterface)(nil).Version))
 }
 
-// Flags mocks base method.
+// Flags mocks base method
 func (m *MockConfigInterface) Flags() ([]plugin.Flag, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Flags")
@@ -156,13 +155,13 @@ func (m *MockConfigInterface) Flags() ([]plugin.Flag, error) {
 	return ret0, ret1
 }
 
-// Flags indicates an expected call of Flags.
+// Flags indicates an expected call of Flags
 func (mr *MockConfigInterfaceMockRecorder) Flags() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flags", reflect.TypeOf((*MockConfigInterface)(nil).Flags))
 }
 
-// Type mocks base method.
+// Type mocks base method
 func (m *MockConfigInterface) Type() (plugin.Type, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Type")
@@ -171,13 +170,13 @@ func (m *MockConfigInterface) Type() (plugin.Type, error) {
 	return ret0, ret1
 }
 
-// Type indicates an expected call of Type.
+// Type indicates an expected call of Type
 func (mr *MockConfigInterfaceMockRecorder) Type() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockConfigInterface)(nil).Type))
 }
 
-// Help mocks base method.
+// Help mocks base method
 func (m *MockConfigInterface) Help() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Help")
@@ -186,13 +185,13 @@ func (m *MockConfigInterface) Help() (string, error) {
 	return ret0, ret1
 }
 
-// Help indicates an expected call of Help.
+// Help indicates an expected call of Help
 func (mr *MockConfigInterfaceMockRecorder) Help() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Help", reflect.TypeOf((*MockConfigInterface)(nil).Help))
 }
 
-// Close mocks base method.
+// Close mocks base method
 func (m *MockConfigInterface) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -200,13 +199,13 @@ func (m *MockConfigInterface) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close.
+// Close indicates an expected call of Close
 func (mr *MockConfigInterfaceMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockConfigInterface)(nil).Close))
 }
 
-// Fetch mocks base method.
+// Fetch mocks base method
 func (m *MockConfigInterface) Fetch(context map[string]string, data interface{}) (map[string]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Fetch", context, data)
@@ -215,36 +214,36 @@ func (m *MockConfigInterface) Fetch(context map[string]string, data interface{})
 	return ret0, ret1
 }
 
-// Fetch indicates an expected call of Fetch.
+// Fetch indicates an expected call of Fetch
 func (mr *MockConfigInterfaceMockRecorder) Fetch(context, data interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fetch", reflect.TypeOf((*MockConfigInterface)(nil).Fetch), context, data)
 }
 
-// MockManifestInterface is a mock of ManifestInterface interface.
+// MockManifestInterface is a mock of ManifestInterface interface
 type MockManifestInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockManifestInterfaceMockRecorder
 }
 
-// MockManifestInterfaceMockRecorder is the mock recorder for MockManifestInterface.
+// MockManifestInterfaceMockRecorder is the mock recorder for MockManifestInterface
 type MockManifestInterfaceMockRecorder struct {
 	mock *MockManifestInterface
 }
 
-// NewMockManifestInterface creates a new mock instance.
+// NewMockManifestInterface creates a new mock instance
 func NewMockManifestInterface(ctrl *gomock.Controller) *MockManifestInterface {
 	mock := &MockManifestInterface{ctrl: ctrl}
 	mock.recorder = &MockManifestInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockManifestInterface) EXPECT() *MockManifestInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Version mocks base method.
+// Version mocks base method
 func (m *MockManifestInterface) Version() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Version")
@@ -253,13 +252,13 @@ func (m *MockManifestInterface) Version() (string, error) {
 	return ret0, ret1
 }
 
-// Version indicates an expected call of Version.
+// Version indicates an expected call of Version
 func (mr *MockManifestInterfaceMockRecorder) Version() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockManifestInterface)(nil).Version))
 }
 
-// Flags mocks base method.
+// Flags mocks base method
 func (m *MockManifestInterface) Flags() ([]plugin.Flag, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Flags")
@@ -268,13 +267,13 @@ func (m *MockManifestInterface) Flags() ([]plugin.Flag, error) {
 	return ret0, ret1
 }
 
-// Flags indicates an expected call of Flags.
+// Flags indicates an expected call of Flags
 func (mr *MockManifestInterfaceMockRecorder) Flags() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flags", reflect.TypeOf((*MockManifestInterface)(nil).Flags))
 }
 
-// Type mocks base method.
+// Type mocks base method
 func (m *MockManifestInterface) Type() (plugin.Type, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Type")
@@ -283,13 +282,13 @@ func (m *MockManifestInterface) Type() (plugin.Type, error) {
 	return ret0, ret1
 }
 
-// Type indicates an expected call of Type.
+// Type indicates an expected call of Type
 func (mr *MockManifestInterfaceMockRecorder) Type() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockManifestInterface)(nil).Type))
 }
 
-// Help mocks base method.
+// Help mocks base method
 func (m *MockManifestInterface) Help() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Help")
@@ -298,13 +297,13 @@ func (m *MockManifestInterface) Help() (string, error) {
 	return ret0, ret1
 }
 
-// Help indicates an expected call of Help.
+// Help indicates an expected call of Help
 func (mr *MockManifestInterfaceMockRecorder) Help() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Help", reflect.TypeOf((*MockManifestInterface)(nil).Help))
 }
 
-// Close mocks base method.
+// Close mocks base method
 func (m *MockManifestInterface) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -312,13 +311,13 @@ func (m *MockManifestInterface) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close.
+// Close indicates an expected call of Close
 func (mr *MockManifestInterfaceMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockManifestInterface)(nil).Close))
 }
 
-// Manifests mocks base method.
+// Manifests mocks base method
 func (m *MockManifestInterface) Manifests(arg0 map[string]string) (stevedore.ManifestFiles, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Manifests", arg0)
@@ -327,7 +326,7 @@ func (m *MockManifestInterface) Manifests(arg0 map[string]string) (stevedore.Man
 	return ret0, ret1
 }
 
-// Manifests indicates an expected call of Manifests.
+// Manifests indicates an expected call of Manifests
 func (mr *MockManifestInterfaceMockRecorder) Manifests(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Manifests", reflect.TypeOf((*MockManifestInterface)(nil).Manifests), arg0)

--- a/pkg/internal/mocks/upstaller/upstaller.go
+++ b/pkg/internal/mocks/upstaller/upstaller.go
@@ -6,45 +6,44 @@ package upstaller
 
 import (
 	context "context"
-	reflect "reflect"
-	sync "sync"
-
 	helm "github.com/gojek/stevedore/pkg/helm"
 	stevedore "github.com/gojek/stevedore/pkg/stevedore"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
+	sync "sync"
 )
 
-// MockUpstaller is a mock of Upstaller interface.
+// MockUpstaller is a mock of Upstaller interface
 type MockUpstaller struct {
 	ctrl     *gomock.Controller
 	recorder *MockUpstallerMockRecorder
 }
 
-// MockUpstallerMockRecorder is the mock recorder for MockUpstaller.
+// MockUpstallerMockRecorder is the mock recorder for MockUpstaller
 type MockUpstallerMockRecorder struct {
 	mock *MockUpstaller
 }
 
-// NewMockUpstaller creates a new mock instance.
+// NewMockUpstaller creates a new mock instance
 func NewMockUpstaller(ctrl *gomock.Controller) *MockUpstaller {
 	mock := &MockUpstaller{ctrl: ctrl}
 	mock.recorder = &MockUpstallerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockUpstaller) EXPECT() *MockUpstallerMockRecorder {
 	return m.recorder
 }
 
-// Upstall mocks base method.
-func (m *MockUpstaller) Upstall(ctx context.Context, client helm.Client, releaseSpecification stevedore.ReleaseSpecification, file string, responseCh chan<- stevedore.Response, proceed chan<- bool, wg *sync.WaitGroup, opts stevedore.Opts, helmTimeout int64) {
+// Upstall mocks base method
+func (m *MockUpstaller) Upstall(ctx context.Context, client helm.Client, releaseSpecification stevedore.ReleaseSpecification, file string, responseCh chan<- stevedore.Response, proceed chan<- bool, wg *sync.WaitGroup, opts stevedore.Opts, helmTimeout int64, helmAtomic bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Upstall", ctx, client, releaseSpecification, file, responseCh, proceed, wg, opts, helmTimeout)
+	m.ctrl.Call(m, "Upstall", ctx, client, releaseSpecification, file, responseCh, proceed, wg, opts, helmTimeout, helmAtomic)
 }
 
-// Upstall indicates an expected call of Upstall.
-func (mr *MockUpstallerMockRecorder) Upstall(ctx, client, releaseSpecification, file, responseCh, proceed, wg, opts, helmTimeout interface{}) *gomock.Call {
+// Upstall indicates an expected call of Upstall
+func (mr *MockUpstallerMockRecorder) Upstall(ctx, client, releaseSpecification, file, responseCh, proceed, wg, opts, helmTimeout, helmAtomic interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upstall", reflect.TypeOf((*MockUpstaller)(nil).Upstall), ctx, client, releaseSpecification, file, responseCh, proceed, wg, opts, helmTimeout)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upstall", reflect.TypeOf((*MockUpstaller)(nil).Upstall), ctx, client, releaseSpecification, file, responseCh, proceed, wg, opts, helmTimeout, helmAtomic)
 }

--- a/pkg/stevedore/stevedore_test.go
+++ b/pkg/stevedore/stevedore_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestStevedoreDo(t *testing.T) {
 	var timeout int64 = 10
+	var atomic bool = false
 
 	t.Run("should do nothing for empty releaseSpecifications", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -30,7 +31,7 @@ func TestStevedoreDo(t *testing.T) {
 			Opts:      opts,
 			Upstaller: upstaller,
 		}
-		responses, err := s.Do(context.TODO(), stevedore.ManifestFiles{}, timeout)
+		responses, err := s.Do(context.TODO(), stevedore.ManifestFiles{}, timeout, atomic)
 
 		assert.Empty(t, responses)
 		assert.Nil(t, err)
@@ -70,7 +71,7 @@ func TestStevedoreDo(t *testing.T) {
 
 		opts := stevedore.Opts{DryRun: true, Parallel: true, Filter: false}
 
-		upstaller.EXPECT().Upstall(context.TODO(), client, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), opts, timeout).Do(func(_, _, releaseSpecification, fileName, responseCh, proceedCh, wg, _ interface{}, t int64) {
+		upstaller.EXPECT().Upstall(context.TODO(), client, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), opts, timeout, atomic).Do(func(_, _, releaseSpecification, fileName, responseCh, proceedCh, wg, _ interface{}, t int64, atomic bool) {
 			proceedCh.(chan<- bool) <- true
 			defer wg.(*sync.WaitGroup).Done()
 
@@ -122,7 +123,7 @@ func TestStevedoreDo(t *testing.T) {
 		}
 		postgresRequest := stevedore.ManifestFile{File: "postgres.yaml", Manifest: manifest}
 		redisRequest := stevedore.ManifestFile{File: "redis.yaml", Manifest: manifest}
-		responses, err := s.Do(context.TODO(), stevedore.ManifestFiles{postgresRequest, redisRequest}, timeout)
+		responses, err := s.Do(context.TODO(), stevedore.ManifestFiles{postgresRequest, redisRequest}, timeout, atomic)
 
 		assert.Len(t, responses, 4)
 		assert.ElementsMatch(t, expectedResponses, responses)
@@ -163,7 +164,7 @@ func TestStevedoreDo(t *testing.T) {
 
 		opts := stevedore.Opts{DryRun: true, Parallel: true, Filter: true}
 
-		upstaller.EXPECT().Upstall(context.TODO(), client, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), opts, timeout).Do(func(_, _, releaseSpecification, fileName, responseCh, proceedCh, wg, _ interface{}, t int64) {
+		upstaller.EXPECT().Upstall(context.TODO(), client, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), opts, timeout, atomic).Do(func(_, _, releaseSpecification, fileName, responseCh, proceedCh, wg, _ interface{}, t int64, atomic bool) {
 			proceedCh.(chan<- bool) <- true
 			defer wg.(*sync.WaitGroup).Done()
 
@@ -207,7 +208,7 @@ func TestStevedoreDo(t *testing.T) {
 		}
 		postgresRequest := stevedore.ManifestFile{File: "postgres.yaml", Manifest: manifest}
 		redisRequest := stevedore.ManifestFile{File: "redis.yaml", Manifest: manifest}
-		responses, err := s.Do(context.TODO(), stevedore.ManifestFiles{postgresRequest, redisRequest}, timeout)
+		responses, err := s.Do(context.TODO(), stevedore.ManifestFiles{postgresRequest, redisRequest}, timeout, atomic)
 
 		assert.Len(t, responses, 2)
 		assert.ElementsMatch(t, expectedResponses, responses)
@@ -259,7 +260,7 @@ func TestStevedoreDo(t *testing.T) {
 			file := "postgres.yaml"
 			opts := stevedore.Opts{DryRun: false, Parallel: false}
 			counter := 0
-			upstaller.EXPECT().Upstall(context.TODO(), client, gomock.Any(), file, gomock.Any(), gomock.Any(), gomock.Any(), opts, timeout).Do(func(_, _, releaseSpecification, _, responseCh, proceedCh, wg, _ interface{}, t int64) {
+			upstaller.EXPECT().Upstall(context.TODO(), client, gomock.Any(), file, gomock.Any(), gomock.Any(), gomock.Any(), opts, timeout, atomic).Do(func(_, _, releaseSpecification, _, responseCh, proceedCh, wg, _ interface{}, t int64, atomic bool) {
 				counter++
 				defer wg.(*sync.WaitGroup).Done()
 
@@ -303,7 +304,7 @@ func TestStevedoreDo(t *testing.T) {
 				Spec:     releaseSpecifications,
 			}
 			manifestFile := stevedore.ManifestFile{File: "postgres.yaml", Manifest: manifest}
-			responses, err := s.Do(context.TODO(), stevedore.ManifestFiles{manifestFile}, timeout)
+			responses, err := s.Do(context.TODO(), stevedore.ManifestFiles{manifestFile}, timeout, atomic)
 
 			assert.Len(t, responses, 2)
 			assert.Equal(t, expectedResponses, responses)
@@ -355,7 +356,7 @@ func TestStevedoreDo(t *testing.T) {
 			file := "postgres.yaml"
 			opts := stevedore.Opts{DryRun: true, Parallel: false}
 			counter := 0
-			upstaller.EXPECT().Upstall(context.TODO(), client, gomock.Any(), file, gomock.Any(), gomock.Any(), gomock.Any(), opts, timeout).Do(func(_, _, releaseSpecification, _, responseCh, proceedCh, wg, _ interface{}, t int64) {
+			upstaller.EXPECT().Upstall(context.TODO(), client, gomock.Any(), file, gomock.Any(), gomock.Any(), gomock.Any(), opts, timeout, atomic).Do(func(_, _, releaseSpecification, _, responseCh, proceedCh, wg, _ interface{}, t int64, atomic bool) {
 				counter++
 				defer wg.(*sync.WaitGroup).Done()
 
@@ -405,7 +406,7 @@ func TestStevedoreDo(t *testing.T) {
 				Spec:     releaseSpecifications,
 			}
 			manifestFile := stevedore.ManifestFile{File: "postgres.yaml", Manifest: manifest}
-			responses, err := s.Do(context.TODO(), stevedore.ManifestFiles{manifestFile}, timeout)
+			responses, err := s.Do(context.TODO(), stevedore.ManifestFiles{manifestFile}, timeout, atomic)
 
 			assert.Len(t, responses, 3)
 			assert.Equal(t, expectedResponses, responses)
@@ -457,7 +458,7 @@ func TestStevedoreDo(t *testing.T) {
 			file := "postgres.yaml"
 			opts := stevedore.Opts{DryRun: false, Parallel: true}
 			counter := 0
-			upstaller.EXPECT().Upstall(context.TODO(), client, gomock.Any(), file, gomock.Any(), gomock.Any(), gomock.Any(), opts, timeout).Do(func(_, _, releaseSpecification, _, responseCh, proceedCh, wg, _ interface{}, t int64) {
+			upstaller.EXPECT().Upstall(context.TODO(), client, gomock.Any(), file, gomock.Any(), gomock.Any(), gomock.Any(), opts, timeout, atomic).Do(func(_, _, releaseSpecification, _, responseCh, proceedCh, wg, _ interface{}, t int64, atomic bool) {
 				counter++
 				defer wg.(*sync.WaitGroup).Done()
 
@@ -507,7 +508,7 @@ func TestStevedoreDo(t *testing.T) {
 				Spec:     releaseSpecifications,
 			}
 			manifestFile := stevedore.ManifestFile{File: "postgres.yaml", Manifest: manifest}
-			responses, err := s.Do(context.TODO(), stevedore.ManifestFiles{manifestFile}, timeout)
+			responses, err := s.Do(context.TODO(), stevedore.ManifestFiles{manifestFile}, timeout, atomic)
 
 			assert.Len(t, responses, 3)
 			assert.Equal(t, expectedResponses, responses)
@@ -559,7 +560,7 @@ func TestStevedoreDo(t *testing.T) {
 			file := "postgres.yaml"
 			opts := stevedore.Opts{DryRun: true, Parallel: true}
 			counter := 0
-			upstaller.EXPECT().Upstall(context.TODO(), client, gomock.Any(), file, gomock.Any(), gomock.Any(), gomock.Any(), opts, timeout).Do(func(_, _, releaseSpecification, _, responseCh, proceedCh, wg, _ interface{}, t int64) {
+			upstaller.EXPECT().Upstall(context.TODO(), client, gomock.Any(), file, gomock.Any(), gomock.Any(), gomock.Any(), opts, timeout, atomic).Do(func(_, _, releaseSpecification, _, responseCh, proceedCh, wg, _ interface{}, t int64, atomic bool) {
 				counter++
 				defer wg.(*sync.WaitGroup).Done()
 
@@ -609,7 +610,7 @@ func TestStevedoreDo(t *testing.T) {
 				Spec:     releaseSpecifications,
 			}
 			manifestFile := stevedore.ManifestFile{File: "postgres.yaml", Manifest: manifest}
-			responses, err := s.Do(context.TODO(), stevedore.ManifestFiles{manifestFile}, timeout)
+			responses, err := s.Do(context.TODO(), stevedore.ManifestFiles{manifestFile}, timeout, atomic)
 
 			assert.Len(t, responses, 3)
 			assert.Equal(t, expectedResponses, responses)
@@ -652,7 +653,7 @@ func TestStevedoreDo(t *testing.T) {
 		file := "releaseSpecifications.yaml"
 
 		opts := stevedore.Opts{DryRun: true, Parallel: true}
-		upstaller.EXPECT().Upstall(context.TODO(), client, gomock.Any(), file, gomock.Any(), gomock.Any(), gomock.Any(), opts, timeout).Do(func(_, _, releaseSpecification, _, responseCh, proceedCh, wg, _ interface{}, t int64) {
+		upstaller.EXPECT().Upstall(context.TODO(), client, gomock.Any(), file, gomock.Any(), gomock.Any(), gomock.Any(), opts, timeout, atomic).Do(func(_, _, releaseSpecification, _, responseCh, proceedCh, wg, _ interface{}, t int64, atomic bool) {
 			defer wg.(*sync.WaitGroup).Done()
 
 			proceedCh.(chan<- bool) <- true
@@ -694,7 +695,7 @@ func TestStevedoreDo(t *testing.T) {
 			Spec:     releaseSpecifications,
 		}
 		manifestFile := stevedore.ManifestFile{File: file, Manifest: manifest}
-		responses, err := s.Do(context.TODO(), stevedore.ManifestFiles{manifestFile}, timeout)
+		responses, err := s.Do(context.TODO(), stevedore.ManifestFiles{manifestFile}, timeout, atomic)
 
 		assert.Len(t, responses, 2)
 		assert.ElementsMatch(t, expectedResponses, responses)
@@ -735,7 +736,7 @@ func TestStevedoreDo(t *testing.T) {
 
 		file := "releaseSpecifications.yaml"
 		opts := stevedore.Opts{DryRun: true, Parallel: true}
-		upstaller.EXPECT().Upstall(context.TODO(), client, gomock.Any(), file, gomock.Any(), gomock.Any(), gomock.Any(), opts, timeout).Do(func(_, _, releaseSpecification, _, responseCh, proceedCh, wg, _ interface{}, t int64) {
+		upstaller.EXPECT().Upstall(context.TODO(), client, gomock.Any(), file, gomock.Any(), gomock.Any(), gomock.Any(), opts, timeout, atomic).Do(func(_, _, releaseSpecification, _, responseCh, proceedCh, wg, _ interface{}, t int64, atomic bool) {
 			defer wg.(*sync.WaitGroup).Done()
 
 			proceedCh.(chan<- bool) <- true
@@ -777,7 +778,7 @@ func TestStevedoreDo(t *testing.T) {
 			Spec:     releaseSpecifications,
 		}
 		manifestFile := stevedore.ManifestFile{File: file, Manifest: manifest}
-		responses, err := s.Do(context.TODO(), stevedore.ManifestFiles{manifestFile}, timeout)
+		responses, err := s.Do(context.TODO(), stevedore.ManifestFiles{manifestFile}, timeout, atomic)
 
 		assert.Len(t, responses, 2)
 		assert.ElementsMatch(t, expectedResponses, responses)

--- a/pkg/stevedore/upstaller.go
+++ b/pkg/stevedore/upstaller.go
@@ -11,7 +11,7 @@ import (
 // Upstaller will release/upgrade a releaseSpecification
 type Upstaller interface {
 	Upstall(ctx context.Context, client helm.Client, releaseSpecification ReleaseSpecification, file string,
-		responseCh chan<- Response, proceed chan<- bool, wg *sync.WaitGroup, opts Opts, helmTimeout int64)
+		responseCh chan<- Response, proceed chan<- bool, wg *sync.WaitGroup, opts Opts, helmTimeout int64, helmAtomic bool)
 }
 
 // HelmUpstaller will release/upgrade a releaseSpecification using helmClient
@@ -19,7 +19,7 @@ type HelmUpstaller struct{}
 
 // Upstall will release/upgrade a releaseSpecification using helmClient
 func (HelmUpstaller) Upstall(ctx context.Context, client helm.Client, releaseSpecification ReleaseSpecification, file string,
-	responseCh chan<- Response, proceed chan<- bool, wg *sync.WaitGroup, opts Opts, helmTimeout int64) {
+	responseCh chan<- Response, proceed chan<- bool, wg *sync.WaitGroup, opts Opts, helmTimeout int64, helmAtomic bool) {
 	defer wg.Done()
 	var err error
 	if opts.Parallel {
@@ -36,7 +36,7 @@ func (HelmUpstaller) Upstall(ctx context.Context, client helm.Client, releaseSpe
 	chartVersion := releaseSpecification.Release.ChartVersion
 	currentReleaseVersion := releaseSpecification.Release.CurrentReleaseVersion
 	values, _ := releaseSpecification.Release.Values.ToYAML()
-	upstallResponse, err = client.Upstall(ctx, manifestName, chartName, chartVersion, currentReleaseVersion, namespace, values, opts.DryRun, helmTimeout)
+	upstallResponse, err = client.Upstall(ctx, manifestName, chartName, chartVersion, currentReleaseVersion, namespace, values, opts.DryRun, helmTimeout, helmAtomic)
 	chartVersion = upstallResponse.ChartVersion
 	newCurrentReleaseVersion := upstallResponse.CurrentReleaseVersion
 	if err != nil {

--- a/pkg/stevedore/upstaller_test.go
+++ b/pkg/stevedore/upstaller_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/databus23/helm-diff/manifest"
 	"github.com/gojek/stevedore/pkg/helm"
-	"github.com/gojek/stevedore/pkg/internal/mocks/helm"
+	mocks "github.com/gojek/stevedore/pkg/internal/mocks/helm"
 	"github.com/gojek/stevedore/pkg/stevedore"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -18,6 +18,7 @@ func TestUpstaller_upstall(t *testing.T) {
 	var currentReleaseVersion int32
 	chartVersion := ""
 	var timeout int64 = 10
+	var atomic bool = true
 	t.Run("should create helm response when helm upstall succeeds", func(t *testing.T) {
 		t.Run("with parallel true", func(t *testing.T) {
 			opts := stevedore.Opts{Parallel: true, DryRun: true}
@@ -48,7 +49,9 @@ func TestUpstaller_upstall(t *testing.T) {
 				currentReleaseVersion,
 				release.Namespace,
 				valuesYaml,
-				opts.DryRun, timeout).Return(upstallResponse, nil)
+				opts.DryRun,
+				timeout,
+				atomic).Return(upstallResponse, nil)
 
 			responseCh := make(chan stevedore.Response)
 			wg := sync.WaitGroup{}
@@ -57,7 +60,7 @@ func TestUpstaller_upstall(t *testing.T) {
 			releaseSpecification := stevedore.ReleaseSpecification{
 				Release: release,
 			}
-			go stevedore.HelmUpstaller{}.Upstall(context.TODO(), client, releaseSpecification, "postgres.yaml", responseCh, proceed, &wg, opts, timeout)
+			go stevedore.HelmUpstaller{}.Upstall(context.TODO(), client, releaseSpecification, "postgres.yaml", responseCh, proceed, &wg, opts, timeout, atomic)
 
 			wgForAssert := sync.WaitGroup{}
 			wgForAssert.Add(1)
@@ -117,7 +120,9 @@ func TestUpstaller_upstall(t *testing.T) {
 				currentReleaseVersion,
 				release.Namespace,
 				valuesYaml,
-				opts.DryRun, timeout).Return(upstallResponse, nil)
+				opts.DryRun,
+				timeout,
+				atomic).Return(upstallResponse, nil)
 
 			responseCh := make(chan stevedore.Response)
 			wg := sync.WaitGroup{}
@@ -126,7 +131,7 @@ func TestUpstaller_upstall(t *testing.T) {
 			releaseSpecification := stevedore.ReleaseSpecification{
 				Release: release,
 			}
-			go stevedore.HelmUpstaller{}.Upstall(context.TODO(), client, releaseSpecification, "postgres.yaml", responseCh, proceed, &wg, opts, timeout)
+			go stevedore.HelmUpstaller{}.Upstall(context.TODO(), client, releaseSpecification, "postgres.yaml", responseCh, proceed, &wg, opts, timeout, atomic)
 
 			wgForAssert := sync.WaitGroup{}
 			wgForAssert.Add(1)
@@ -186,7 +191,9 @@ func TestUpstaller_upstall(t *testing.T) {
 			currentReleaseVersion,
 			release.Namespace,
 			valuesYaml,
-			opts.DryRun, timeout).Return(upstallResponse, nil)
+			opts.DryRun,
+			timeout,
+			atomic).Return(upstallResponse, nil)
 
 		responseCh := make(chan stevedore.Response)
 		wg := sync.WaitGroup{}
@@ -195,7 +202,7 @@ func TestUpstaller_upstall(t *testing.T) {
 		releaseSpecification := stevedore.ReleaseSpecification{
 			Release: release,
 		}
-		go stevedore.HelmUpstaller{}.Upstall(context.TODO(), client, releaseSpecification, "postgres.yaml", responseCh, proceed, &wg, opts, timeout)
+		go stevedore.HelmUpstaller{}.Upstall(context.TODO(), client, releaseSpecification, "postgres.yaml", responseCh, proceed, &wg, opts, timeout, atomic)
 
 		<-proceed
 
@@ -244,7 +251,8 @@ func TestUpstaller_upstall(t *testing.T) {
 				currentReleaseVersion,
 				release.Namespace,
 				valuesYaml,
-				opts.DryRun, timeout).Return(helm.UpstallResponse{}, fmt.Errorf("something went wrong"))
+				opts.DryRun,
+				timeout, atomic).Return(helm.UpstallResponse{}, fmt.Errorf("something went wrong"))
 
 			responseCh := make(chan stevedore.Response)
 			wg := sync.WaitGroup{}
@@ -253,7 +261,7 @@ func TestUpstaller_upstall(t *testing.T) {
 			releaseSpecification := stevedore.ReleaseSpecification{
 				Release: release,
 			}
-			go stevedore.HelmUpstaller{}.Upstall(context.TODO(), client, releaseSpecification, "postgres.yaml", responseCh, proceed, &wg, opts, timeout)
+			go stevedore.HelmUpstaller{}.Upstall(context.TODO(), client, releaseSpecification, "postgres.yaml", responseCh, proceed, &wg, opts, timeout, atomic)
 
 			wgForAssert := sync.WaitGroup{}
 			wgForAssert.Add(1)
@@ -307,7 +315,8 @@ func TestUpstaller_upstall(t *testing.T) {
 				currentReleaseVersion,
 				release.Namespace,
 				valuesYaml,
-				opts.DryRun, timeout).Return(helm.UpstallResponse{}, fmt.Errorf("something went wrong"))
+				opts.DryRun,
+				timeout, atomic).Return(helm.UpstallResponse{}, fmt.Errorf("something went wrong"))
 
 			responseCh := make(chan stevedore.Response)
 			wg := sync.WaitGroup{}
@@ -316,7 +325,7 @@ func TestUpstaller_upstall(t *testing.T) {
 			releaseSpecification := stevedore.ReleaseSpecification{
 				Release: release,
 			}
-			go stevedore.HelmUpstaller{}.Upstall(context.TODO(), client, releaseSpecification, "postgres.yaml", responseCh, proceed, &wg, opts, timeout)
+			go stevedore.HelmUpstaller{}.Upstall(context.TODO(), client, releaseSpecification, "postgres.yaml", responseCh, proceed, &wg, opts, timeout, atomic)
 
 			wgForAssert := sync.WaitGroup{}
 			wgForAssert.Add(1)


### PR DESCRIPTION
From the `helm` CLI referece:

`--atomic`  -  if set, the installation process deletes the installation on failure. The --wait flag will be set automatically if --atomic is used

`--wait`  -  if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful. It will wait for as long as --timeout

This PR allows to enable atomic installation by passing `--helm-atomic` to `stevedore apply` command.

```
 --helm-atomic    Wait for resources to become ready and delete installation on failure (default: false)
```